### PR TITLE
Normalize JSON:API resource ids

### DIFF
--- a/plugins/core/lib/querying-writing/resource-id-normalization.js
+++ b/plugins/core/lib/querying-writing/resource-id-normalization.js
@@ -1,0 +1,131 @@
+import {
+  RestApiResourceError,
+  RestApiValidationError
+} from '../../../../lib/rest-api-errors.js'
+
+export function defaultNormalizeResourceId (value) {
+  if (value === null || value === undefined) {
+    return null
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim()
+    return normalized || null
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? String(value) : null
+  }
+
+  if (typeof value === 'bigint') {
+    return String(value)
+  }
+
+  const normalized = String(value).trim()
+  return normalized || null
+}
+
+export function resolveResourceIdNormalizer ({ scopeOptions = null, vars = null } = {}) {
+  if (typeof scopeOptions?.normalizeId === 'function') {
+    return scopeOptions.normalizeId
+  }
+
+  if (typeof vars?.normalizeId === 'function') {
+    return vars.normalizeId
+  }
+
+  return defaultNormalizeResourceId
+}
+
+export function normalizeResourceId (value, options = {}) {
+  const normalizer = resolveResourceIdNormalizer(options)
+  return defaultNormalizeResourceId(normalizer(value))
+}
+
+export function requireExistingResourceId (value, {
+  scopeOptions = null,
+  vars = null,
+  scopeName = ''
+} = {}) {
+  const normalizedId = normalizeResourceId(value, { scopeOptions, vars })
+  if (normalizedId) {
+    return normalizedId
+  }
+
+  throw new RestApiResourceError(
+    'Resource not found',
+    {
+      subtype: 'not_found',
+      resourceType: scopeName,
+      resourceId: value == null ? null : String(value)
+    }
+  )
+}
+
+export function requireDocumentResourceId (value, {
+  scopeOptions = null,
+  vars = null
+} = {}) {
+  const normalizedId = normalizeResourceId(value, { scopeOptions, vars })
+  if (normalizedId) {
+    return normalizedId
+  }
+
+  throw new RestApiValidationError(
+    'Resource document id is invalid',
+    {
+      fields: ['data.id'],
+      violations: [{
+        field: 'data.id',
+        rule: 'invalid_resource_id',
+        message: 'Resource document id must normalize to a non-empty value.'
+      }]
+    }
+  )
+}
+
+function resolveResourceNormalizationOptions (resourceType, { api } = {}) {
+  const scope = api?.resources?.[resourceType]
+  return {
+    scopeOptions: scope?.scopeOptions || scope?._scopeOptions || null,
+    vars: scope?.vars || null,
+    scopeName: resourceType
+  }
+}
+
+export function requireReferencedResourceId (resourceType, value, { api } = {}) {
+  return requireExistingResourceId(
+    value,
+    resolveResourceNormalizationOptions(resourceType, { api })
+  )
+}
+
+function normalizeRelationshipIdentifier (identifier, { api } = {}) {
+  if (!identifier || typeof identifier !== 'object' || Array.isArray(identifier)) {
+    return identifier
+  }
+
+  const type = typeof identifier.type === 'string' ? identifier.type : ''
+  if (!type || !Object.hasOwn(identifier, 'id')) {
+    return {
+      ...identifier
+    }
+  }
+
+  return {
+    ...identifier,
+    id: requireReferencedResourceId(type, identifier.id, { api })
+  }
+}
+
+export function normalizeRelationshipIdentifiers (relationshipData, { api } = {}) {
+  if (Array.isArray(relationshipData)) {
+    return relationshipData.map((identifier) => normalizeRelationshipIdentifier(identifier, { api }))
+  }
+
+  if (relationshipData == null) {
+    return relationshipData
+  }
+
+  return normalizeRelationshipIdentifier(relationshipData, { api })
+}

--- a/plugins/core/lib/writing/many-to-many-manipulations.js
+++ b/plugins/core/lib/writing/many-to-many-manipulations.js
@@ -1,5 +1,6 @@
 import { RestApiResourceError } from '../../../../lib/rest-api-errors.js'
 import { transformSimplifiedToJsonApi } from '../querying-writing/simplified-helpers.js'
+import { normalizeRelationshipIdentifiers } from '../querying-writing/resource-id-normalization.js'
 
 /**
  * Updates many-to-many relationships intelligently by synchronizing pivot table records
@@ -103,7 +104,8 @@ import { transformSimplifiedToJsonApi } from '../querying-writing/simplified-hel
 export const updateManyToManyRelationship = async (scope, deps) => {
   // Extract values from deps
   const { api, context } = deps
-  const { resourceId, relDef, relData, transaction: trx } = context
+  const { resourceId, relDef, transaction: trx } = context
+  const relData = normalizeRelationshipIdentifiers(context.relData || [], { api })
 
   // Get the knex instance from the pivot scope
   const pivotScope = api.resources[relDef.through]
@@ -257,6 +259,7 @@ export const updateManyToManyRelationship = async (scope, deps) => {
  * 6. Returns (no data returned, throws on error)
  */
 export const createPivotRecords = async (api, resourceId, relDef, relData, trx) => {
+  relData = normalizeRelationshipIdentifiers(relData, { api })
   if (relData.length === 0) return // Early exit if nothing to create
 
   // Get pivot table info

--- a/plugins/core/rest-api-plugin-hooks/turn-scope-init-into-vars.js
+++ b/plugins/core/rest-api-plugin-hooks/turn-scope-init-into-vars.js
@@ -24,6 +24,7 @@ export default async function turnScopeInitIntoVars ({ context, scopes, vars: ap
 
   // Set idProperty as scope var
   if (typeof scopeOptions.idProperty !== 'undefined') vars.idProperty = scopeOptions.idProperty
+  if (typeof scopeOptions.normalizeId === 'function') vars.normalizeId = scopeOptions.normalizeId
 
   // Add validation for query limits
   if (vars.queryDefaultLimit && vars.queryMaxLimit) {

--- a/plugins/core/rest-api-plugin-methods/common.js
+++ b/plugins/core/rest-api-plugin-methods/common.js
@@ -3,6 +3,7 @@ import {
   RestApiValidationError
 } from '../../../lib/rest-api-errors.js'
 import { transformSimplifiedToJsonApi } from '../lib/querying-writing/simplified-helpers.js'
+import { normalizeRelationshipIdentifiers } from '../lib/querying-writing/resource-id-normalization.js'
 import { createEnhancedLogger } from '../../../lib/enhanced-logger.js'
 import { unwrapQueryBuilderState } from '../lib/querying/query-builder-utils.js'
 
@@ -443,8 +444,16 @@ export const validateRelationshipAccess = async (context, inputRecord, helpers, 
   for (const [relName, relData] of Object.entries(inputRecord.data.relationships)) {
     if (!relData?.data) continue
 
+    const normalizedRelationshipData = normalizeRelationshipIdentifiers(relData.data, { api })
+    inputRecord.data.relationships[relName] = {
+      ...relData,
+      data: normalizedRelationshipData
+    }
+
     // Handle both single and array relationships
-    const relatedItems = Array.isArray(relData.data) ? relData.data : [relData.data]
+    const relatedItems = Array.isArray(normalizedRelationshipData)
+      ? normalizedRelationshipData
+      : [normalizedRelationshipData]
 
     for (const item of relatedItems) {
       // Get the scope for the related resource

--- a/plugins/core/rest-api-plugin-methods/delete-relationship.js
+++ b/plugins/core/rest-api-plugin-methods/delete-relationship.js
@@ -1,5 +1,9 @@
 import { RestApiResourceError, RestApiValidationError, RestApiPayloadError } from '../../../lib/rest-api-errors.js'
 import { findRelationshipDefinition, handleWriteMethodError } from './common.js'
+import {
+  normalizeRelationshipIdentifiers,
+  requireExistingResourceId
+} from '../lib/querying-writing/resource-id-normalization.js'
 
 /**
  * DELETE RELATIONSHIP
@@ -11,9 +15,13 @@ import { findRelationshipDefinition, handleWriteMethodError } from './common.js'
  * @param {array} relationshipData - Array of resource identifiers to remove
  * @returns {Promise<void>} 204 No Content
  */
-export default async function deleteRelationshipMethod ({ params, context, vars, helpers, scope, scopes, runHooks, scopeName, api, log }) {
+export default async function deleteRelationshipMethod ({ params, context, vars, helpers, scope, scopes, runHooks, scopeOptions, scopeName, api, log }) {
   context.method = 'deleteRelationship'
-  context.id = params.id
+  context.id = requireExistingResourceId(params.id, {
+    scopeOptions,
+    vars,
+    scopeName
+  })
   context.relationshipName = params.relationshipName
   context.schemaInfo = scopes[scopeName].vars.schemaInfo
 
@@ -43,6 +51,7 @@ export default async function deleteRelationshipMethod ({ params, context, vars,
     if (!Array.isArray(params.relationshipData)) {
       throw new RestApiPayloadError('DELETE from relationship requires array of resource identifiers')
     }
+    params.relationshipData = normalizeRelationshipIdentifiers(params.relationshipData, { api })
 
     // Check permissions
     await runHooks('checkPermissions')

--- a/plugins/core/rest-api-plugin-methods/delete.js
+++ b/plugins/core/rest-api-plugin-methods/delete.js
@@ -1,5 +1,6 @@
 import { RestApiResourceError } from '../../../lib/rest-api-errors.js'
 import { handleWriteMethodError } from './common.js'
+import { requireExistingResourceId } from '../lib/querying-writing/resource-id-normalization.js'
 
 /**
  * DELETE
@@ -26,7 +27,11 @@ export default async function deleteMethod ({
   context.method = 'delete'
 
   // Set the ID in context
-  context.id = params.id
+  context.id = requireExistingResourceId(params.id, {
+    scopeOptions,
+    vars,
+    scopeName
+  })
 
   // Set scopeName in context (needed for broadcasting)
   context.scopeName = scopeName

--- a/plugins/core/rest-api-plugin-methods/get-related.js
+++ b/plugins/core/rest-api-plugin-methods/get-related.js
@@ -1,6 +1,7 @@
 import { RestApiResourceError } from '../../../lib/rest-api-errors.js'
 import { findRelationshipDefinition } from './common.js'
 import { buildRelationshipUrl } from '../lib/querying/url-helpers.js'
+import { requireExistingResourceId } from '../lib/querying-writing/resource-id-normalization.js'
 
 /**
  * GET RELATED
@@ -12,9 +13,13 @@ import { buildRelationshipUrl } from '../lib/querying/url-helpers.js'
  * @param {object} queryParams - Standard query parameters
  * @returns {Promise<object>} Related resources with full data
  */
-export default async function getRelatedMethod ({ params, context, vars, helpers, scope, scopes, runHooks, scopeName, api }) {
+export default async function getRelatedMethod ({ params, context, vars, helpers, scope, scopes, runHooks, scopeOptions, scopeName, api }) {
   context.method = 'getRelated'
-  context.id = params.id
+  context.id = requireExistingResourceId(params.id, {
+    scopeOptions,
+    vars,
+    scopeName
+  })
   context.relationshipName = params.relationshipName
   context.queryParams = params.queryParams || {}
   context.schemaInfo = scopes[scopeName].vars.schemaInfo

--- a/plugins/core/rest-api-plugin-methods/get-relationship.js
+++ b/plugins/core/rest-api-plugin-methods/get-relationship.js
@@ -1,6 +1,7 @@
 import { RestApiResourceError } from '../../../lib/rest-api-errors.js'
 import { findRelationshipDefinition } from './common.js'
 import { buildRelationshipUrl } from '../lib/querying/url-helpers.js'
+import { requireExistingResourceId } from '../lib/querying-writing/resource-id-normalization.js'
 
 /**
  * GET RELATIONSHIP
@@ -11,9 +12,13 @@ import { buildRelationshipUrl } from '../lib/querying/url-helpers.js'
  * @param {string} relationshipName - The name of the relationship
  * @returns {Promise<object>} Relationship linkage with links
  */
-export default async function getRelationshipMethod ({ params, context, vars, helpers, scope, scopes, runHooks, scopeName, api }) {
+export default async function getRelationshipMethod ({ params, context, vars, helpers, scope, scopes, runHooks, scopeOptions, scopeName, api }) {
   context.method = 'getRelationship'
-  context.id = params.id
+  context.id = requireExistingResourceId(params.id, {
+    scopeOptions,
+    vars,
+    scopeName
+  })
   context.relationshipName = params.relationshipName
   context.schemaInfo = scopes[scopeName].vars.schemaInfo
 

--- a/plugins/core/rest-api-plugin-methods/get.js
+++ b/plugins/core/rest-api-plugin-methods/get.js
@@ -3,6 +3,7 @@ import { normalizeRecordAttributes } from '../lib/querying-writing/database-valu
 import { getRequestedComputedFields } from '../lib/querying-writing/knex-field-helpers.js'
 import { transformJsonApiToSimplified } from '../lib/querying-writing/simplified-helpers.js'
 import { getRequestContracts, validateRequestContractOrThrow } from '../lib/querying-writing/request-contracts.js'
+import { requireExistingResourceId } from '../lib/querying-writing/resource-id-normalization.js'
 import { cascadeConfig } from './common.js'
 
 /**
@@ -62,10 +63,15 @@ export default async function getMethod ({
     includeDepthLimit: vars.includeDepthLimit,
     sortableFields: vars.sortableFields
   })
+  const normalizedId = requireExistingResourceId(params.id, {
+    scopeOptions,
+    vars,
+    scopeName
+  })
   const validatedRequest = validateRequestContractOrThrow(
     requestContracts.get,
     {
-      id: params.id,
+      id: normalizedId,
       queryParams: context.queryParams
     },
     'GET request parameters are invalid'

--- a/plugins/core/rest-api-plugin-methods/patch-relationship.js
+++ b/plugins/core/rest-api-plugin-methods/patch-relationship.js
@@ -1,3 +1,6 @@
+import { handleWriteMethodError } from './common.js'
+import { requireExistingResourceId } from '../lib/querying-writing/resource-id-normalization.js'
+
 /**
  * PATCH RELATIONSHIP
  * Completely replaces a relationship
@@ -8,9 +11,13 @@
  * @param {object|array} relationshipData - New relationship data
  * @returns {Promise<void>} 204 No Content
  */
-export default async function patchRelationshipMethod ({ params, context, vars, helpers, scope, scopes, runHooks, scopeName, api }) {
+export default async function patchRelationshipMethod ({ params, context, vars, helpers, scope, scopes, runHooks, scopeOptions, scopeName, api, log }) {
   context.method = 'patchRelationship'
-  context.id = params.id
+  context.id = requireExistingResourceId(params.id, {
+    scopeOptions,
+    vars,
+    scopeName
+  })
   context.relationshipName = params.relationshipName
 
   // Transaction handling
@@ -50,6 +57,6 @@ export default async function patchRelationshipMethod ({ params, context, vars, 
 
     // 204 No Content
   } catch (error) {
-    await handleWriteMethodError(error, context, 'PATCH_RELATIONSHIP', scopeName, log)
+    await handleWriteMethodError(error, context, 'PATCH_RELATIONSHIP', scopeName, log, runHooks)
   }
 }

--- a/plugins/core/rest-api-plugin-methods/patch.js
+++ b/plugins/core/rest-api-plugin-methods/patch.js
@@ -4,6 +4,10 @@ import { updateManyToManyRelationship } from '../lib/writing/many-to-many-manipu
 import { ERROR_SUBTYPES } from '../lib/querying-writing/knex-constants.js'
 import { getRequestContracts, validateRequestContractOrThrow } from '../lib/querying-writing/request-contracts.js'
 import {
+  requireDocumentResourceId,
+  requireExistingResourceId
+} from '../lib/querying-writing/resource-id-normalization.js'
+import {
   setupCommonRequest,
   validateResourceAttributesBeforeWrite,
   validateRelationshipAccess,
@@ -59,14 +63,37 @@ export default async function patchMethod ({
       includeDepthLimit: vars.includeDepthLimit,
       sortableFields: vars.sortableFields
     })
+    const normalizedPathId = params.id === undefined
+      ? null
+      : requireExistingResourceId(params.id, {
+          scopeOptions,
+          vars,
+          scopeName
+        })
+
+    if (normalizedPathId && !context.inputRecord?.data?.id) {
+      context.inputRecord = {
+        ...context.inputRecord,
+        data: {
+          ...(context.inputRecord?.data || {}),
+          id: normalizedPathId
+        }
+      }
+    }
+
     context.inputRecord = validateRequestContractOrThrow(
       requestContracts.patch,
       context.inputRecord,
       'PATCH request body is invalid'
     )
-    if (params.id && String(params.id) !== String(context.inputRecord.data.id)) {
+    const normalizedBodyId = requireDocumentResourceId(context.inputRecord.data.id, {
+      scopeOptions,
+      vars
+    })
+
+    if (normalizedPathId && normalizedPathId !== normalizedBodyId) {
       throw new RestApiValidationError(
-        `ID mismatch. URL path ID '${params.id}' does not match request body ID '${context.inputRecord.data.id}'`,
+        `ID mismatch. URL path ID '${normalizedPathId}' does not match request body ID '${normalizedBodyId}'`,
         {
           fields: ['data.id'],
           violations: [{
@@ -77,7 +104,8 @@ export default async function patchMethod ({
         }
       )
     }
-    context.id = params.id || context.inputRecord.data.id
+    context.inputRecord.data.id = normalizedBodyId
+    context.id = normalizedPathId || normalizedBodyId
 
     // Validate that user has read access to all related resources
     // This ensures users can only create relationships to resources they can access

--- a/plugins/core/rest-api-plugin-methods/post-relationship.js
+++ b/plugins/core/rest-api-plugin-methods/post-relationship.js
@@ -1,6 +1,10 @@
 import { RestApiResourceError, RestApiValidationError, RestApiPayloadError } from '../../../lib/rest-api-errors.js'
 import { findRelationshipDefinition, handleWriteMethodError } from './common.js'
 import { createPivotRecords } from '../lib/writing/many-to-many-manipulations.js'
+import {
+  normalizeRelationshipIdentifiers,
+  requireExistingResourceId
+} from '../lib/querying-writing/resource-id-normalization.js'
 
 /**
    * POST RELATIONSHIP
@@ -12,9 +16,13 @@ import { createPivotRecords } from '../lib/writing/many-to-many-manipulations.js
    * @param {array} relationshipData - Array of resource identifiers to add
    * @returns {Promise<void>} 204 No Content
   */
-export default async function postRelationshipMethod ({ params, context, vars, helpers, scope, scopes, runHooks, scopeName, api, log }) {
+export default async function postRelationshipMethod ({ params, context, vars, helpers, scope, scopes, runHooks, scopeOptions, scopeName, api, log }) {
   context.method = 'postRelationship'
-  context.id = params.id
+  context.id = requireExistingResourceId(params.id, {
+    scopeOptions,
+    vars,
+    scopeName
+  })
   context.relationshipName = params.relationshipName
   context.schemaInfo = scopes[scopeName].vars.schemaInfo
 
@@ -45,6 +53,7 @@ export default async function postRelationshipMethod ({ params, context, vars, h
     if (!Array.isArray(params.relationshipData)) {
       throw new RestApiPayloadError('POST to relationship requires array of resource identifiers')
     }
+    params.relationshipData = normalizeRelationshipIdentifiers(params.relationshipData, { api })
 
     // Check permissions
     await runHooks('checkPermissions')

--- a/plugins/core/rest-api-plugin-methods/post.js
+++ b/plugins/core/rest-api-plugin-methods/post.js
@@ -1,6 +1,7 @@
 import { processRelationships } from '../lib/writing/relationship-processor.js'
 import { getRequestContracts, validateRequestContractOrThrow } from '../lib/querying-writing/request-contracts.js'
 import { createPivotRecords } from '../lib/writing/many-to-many-manipulations.js'
+import { requireDocumentResourceId } from '../lib/querying-writing/resource-id-normalization.js'
 import {
   setupCommonRequest,
   validateResourceAttributesBeforeWrite,
@@ -61,6 +62,13 @@ export default async function postMethod ({
       context.inputRecord,
       'POST request body is invalid'
     )
+
+    if (context.inputRecord?.data?.id !== undefined) {
+      context.inputRecord.data.id = requireDocumentResourceId(context.inputRecord.data.id, {
+        scopeOptions,
+        vars
+      })
+    }
 
     // Validate that user has read access to all related resources
     // This ensures users can only create relationships to resources they can access

--- a/plugins/core/rest-api-plugin-methods/put.js
+++ b/plugins/core/rest-api-plugin-methods/put.js
@@ -4,6 +4,10 @@ import { updateManyToManyRelationship, createPivotRecords } from '../lib/writing
 import { ERROR_SUBTYPES } from '../lib/querying-writing/knex-constants.js'
 import { getRequestContracts, validateRequestContractOrThrow } from '../lib/querying-writing/request-contracts.js'
 import {
+  requireDocumentResourceId,
+  requireExistingResourceId
+} from '../lib/querying-writing/resource-id-normalization.js'
+import {
   setupCommonRequest,
   validateCompleteReplacePayload,
   validateResourceAttributesBeforeWrite,
@@ -61,14 +65,37 @@ export default async function putMethod ({
       includeDepthLimit: vars.includeDepthLimit,
       sortableFields: vars.sortableFields
     })
+    const normalizedPathId = params.id === undefined
+      ? null
+      : requireExistingResourceId(params.id, {
+          scopeOptions,
+          vars,
+          scopeName
+        })
+
+    if (normalizedPathId && !context.inputRecord?.data?.id) {
+      context.inputRecord = {
+        ...context.inputRecord,
+        data: {
+          ...(context.inputRecord?.data || {}),
+          id: normalizedPathId
+        }
+      }
+    }
+
     context.inputRecord = validateRequestContractOrThrow(
       requestContracts.put,
       context.inputRecord,
       'PUT request body is invalid'
     )
-    if (params.id && String(params.id) !== String(context.inputRecord.data.id)) {
+    const normalizedBodyId = requireDocumentResourceId(context.inputRecord.data.id, {
+      scopeOptions,
+      vars
+    })
+
+    if (normalizedPathId && normalizedPathId !== normalizedBodyId) {
       throw new RestApiValidationError(
-        `ID mismatch. URL path ID '${params.id}' does not match request body ID '${context.inputRecord.data.id}'`,
+        `ID mismatch. URL path ID '${normalizedPathId}' does not match request body ID '${normalizedBodyId}'`,
         {
           fields: ['data.id'],
           violations: [{
@@ -79,7 +106,8 @@ export default async function putMethod ({
         }
       )
     }
-    context.id = params.id || context.inputRecord.data.id
+    context.inputRecord.data.id = normalizedBodyId
+    context.id = normalizedPathId || normalizedBodyId
 
     // Validate that user has read access to all related resources
     // This ensures users can only create relationships to resources they can access

--- a/plugins/core/rest-api-plugin.js
+++ b/plugins/core/rest-api-plugin.js
@@ -27,6 +27,7 @@ import postRelationshipMethod from './rest-api-plugin-methods/post-relationship.
 import getRelationshipMethod from './rest-api-plugin-methods/get-relationship.js'
 import patchRelationshipMethod from './rest-api-plugin-methods/patch-relationship.js'
 import deleteRelationshipMethod from './rest-api-plugin-methods/delete-relationship.js'
+import { defaultNormalizeResourceId } from './lib/querying-writing/resource-id-normalization.js'
 
 export const RestApiPlugin = {
   name: 'rest-api',
@@ -66,6 +67,9 @@ export const RestApiPlugin = {
       : true // Default true for better DX in programmatic API
 
     vars.idProperty = restApiOptions.idProperty || 'id'
+    vars.normalizeId = typeof restApiOptions.normalizeId === 'function'
+      ? restApiOptions.normalizeId
+      : defaultNormalizeResourceId
 
     // Return full record configuration for API and Transport
     // Support values: 'no', 'minimal', 'full'

--- a/tests/fixtures/api-configs.js
+++ b/tests/fixtures/api-configs.js
@@ -199,6 +199,139 @@ export async function createBasicApi (knex, pluginOptions = {}) {
 }
 
 /**
+ * Creates a small API focused on resource ID normalization behavior.
+ */
+export async function createIdNormalizationApi (knex, pluginOptions = {}) {
+  const apiName = pluginOptions.apiName || 'id-normalization-test-api'
+  const tablePrefix = pluginOptions.tablePrefix || 'id_norm'
+  if (storageMode.isAnyApi()) {
+    storageMode.clearRegistry()
+  }
+
+  const api = new Api({
+    name: apiName,
+    log: { level: process.env.LOG_LEVEL || 'info' }
+  })
+
+  const previousTenant = storageMode.currentTenant
+  const tenantId = storageMode.isAnyApi()
+    ? (pluginOptions.tenantId || `${tablePrefix}_tenant`)
+    : storageMode.defaultTenant
+  if (storageMode.isAnyApi()) {
+    storageMode.setCurrentTenant(tenantId)
+  }
+
+  await api.use(RestApiPlugin, {
+    simplifiedApi: false,
+    simplifiedTransport: false,
+    returnRecordApi: {
+      post: true,
+      put: false,
+      patch: false
+    },
+    returnRecordTransport: {
+      post: 'full',
+      put: 'no',
+      patch: 'minimal'
+    },
+    ...(pluginOptions['rest-api'] || {})
+  })
+
+  try {
+    await withTenantContext(tenantId, async () => {
+      await useStoragePlugin(api, knex, { tenantId })
+      await resetAnyApiTables(knex)
+
+      await api.addResource('countries', {
+        schema: {
+          id: { type: 'string', required: true },
+          name: { type: 'string', required: true, max: 100 }
+        },
+        tableName: `${tablePrefix}_countries`,
+        ...(pluginOptions.countryResourceOptions || {})
+      })
+      await knex.schema.dropTableIfExists(`${tablePrefix}_countries`)
+      await knex.schema.createTable(`${tablePrefix}_countries`, (table) => {
+        table.string('id').primary()
+        table.string('name').notNullable()
+      })
+      mapTable(`${tablePrefix}_countries`, 'countries')
+
+      await api.addResource('publishers', {
+        schema: {
+          id: { type: 'string', required: true },
+          name: { type: 'string', required: true, max: 100 },
+          country_id: { type: 'string', nullable: true, belongsTo: 'countries', as: 'country' }
+        },
+        relationships: {
+          tags: { type: 'manyToMany', through: 'publisher_tags', foreignKey: 'publisher_id', otherKey: 'tag_id' }
+        },
+        tableName: `${tablePrefix}_publishers`,
+        ...(pluginOptions.publisherResourceOptions || {})
+      })
+      await knex.schema.dropTableIfExists(`${tablePrefix}_publishers`)
+      await knex.schema.createTable(`${tablePrefix}_publishers`, (table) => {
+        table.string('id').primary()
+        table.string('name').notNullable()
+        table.string('country_id').nullable()
+      })
+      mapTable(`${tablePrefix}_publishers`, 'publishers')
+
+      await api.addResource('tags', {
+        schema: {
+          id: { type: 'string', required: true },
+          name: { type: 'string', required: true, max: 100 }
+        },
+        tableName: `${tablePrefix}_tags`,
+        ...(pluginOptions.tagResourceOptions || {})
+      })
+      await knex.schema.dropTableIfExists(`${tablePrefix}_tags`)
+      await knex.schema.createTable(`${tablePrefix}_tags`, (table) => {
+        table.string('id').primary()
+        table.string('name').notNullable()
+      })
+      mapTable(`${tablePrefix}_tags`, 'tags')
+
+      await api.addResource('publisher_tags', {
+        schema: {
+          id: { type: 'id' },
+          publisher_id: { type: 'string', required: true, belongsTo: 'publishers', as: 'publisher' },
+          tag_id: { type: 'string', required: true, belongsTo: 'tags', as: 'tag' }
+        },
+        tableName: `${tablePrefix}_publisher_tags`
+      })
+      await knex.schema.dropTableIfExists(`${tablePrefix}_publisher_tags`)
+      await knex.schema.createTable(`${tablePrefix}_publisher_tags`, (table) => {
+        table.increments('id').primary()
+        table.string('publisher_id').notNullable()
+        table.string('tag_id').notNullable()
+      })
+      mapTable(`${tablePrefix}_publisher_tags`, 'publisher_tags')
+      if (storageMode.isAnyApi()) {
+        const descriptorTenant = api.anyapi?.tenantId || tenantId
+        const publishersDescriptor = await api.anyapi.registry.getDescriptor(descriptorTenant, 'publishers')
+        const tagsDescriptor = await api.anyapi.registry.getDescriptor(descriptorTenant, 'tags')
+        const relationshipKey = publishersDescriptor?.manyToMany?.tags?.relationship
+        const inverseRelationshipKey = tagsDescriptor?.manyToMany?.publishers?.relationship
+        storageMode.registerLink(
+          `${tablePrefix}_publisher_tags`,
+          'publishers',
+          'tags',
+          relationshipKey,
+          inverseRelationshipKey
+        )
+      }
+    })
+
+    return api
+  } finally {
+    if (storageMode.isAnyApi()) {
+      storageMode.setCurrentTenant(previousTenant)
+    }
+  }
+}
+
+/**
  * Creates a basic API with bulk operations enabled
  */
 export async function createBulkOperationsApi (knex, pluginOptions = {}) {

--- a/tests/id-normalization.test.js
+++ b/tests/id-normalization.test.js
@@ -1,0 +1,270 @@
+import { describe, it, before, after, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import knexLib from 'knex'
+
+import {
+  cleanTables,
+  createJsonApiDocument,
+  validateJsonApiStructure
+} from './helpers/test-utils.js'
+import { createIdNormalizationApi } from './fixtures/api-configs.js'
+
+const knex = knexLib({
+  client: 'better-sqlite3',
+  connection: {
+    filename: ':memory:'
+  },
+  useNullAsDefault: true
+})
+
+let defaultApi
+let overrideApi
+
+describe('Resource ID normalization', () => {
+  before(async () => {
+    defaultApi = await createIdNormalizationApi(knex, {
+      tablePrefix: 'id_norm_default'
+    })
+
+    overrideApi = await createIdNormalizationApi(knex, {
+      tablePrefix: 'id_norm_override',
+      'rest-api': {
+        returnRecordApi: {
+          post: 'no',
+          put: false,
+          patch: false
+        },
+        normalizeId: (value) => {
+          if (value === null || value === undefined) {
+            return null
+          }
+
+          const normalized = String(value).trim()
+          return normalized ? normalized.toUpperCase() : null
+        }
+      },
+      countryResourceOptions: {
+        normalizeId: (value) => {
+          if (value === null || value === undefined) {
+            return null
+          }
+
+          const normalized = String(value).trim()
+          return normalized ? normalized.toLowerCase() : null
+        }
+      },
+      tagResourceOptions: {
+        normalizeId: (value) => {
+          if (value === null || value === undefined) {
+            return null
+          }
+
+          const normalized = String(value).trim()
+          return normalized ? normalized.toLowerCase() : null
+        }
+      }
+    })
+  })
+
+  after(async () => {
+    await knex.destroy()
+  })
+
+  beforeEach(async () => {
+    await cleanTables(knex, [
+      'id_norm_default_countries',
+      'id_norm_default_publishers',
+      'id_norm_default_tags',
+      'id_norm_default_publisher_tags',
+      'id_norm_override_countries',
+      'id_norm_override_publishers',
+      'id_norm_override_tags',
+      'id_norm_override_publisher_tags'
+    ])
+  })
+
+  it('uses the default normalizer to trim surrounding whitespace', async () => {
+    const countryId = 'country-default'
+    const countryDoc = createJsonApiDocument('countries', {
+      name: 'Canada'
+    })
+    countryDoc.data.id = countryId
+
+    await defaultApi.resources.countries.post({
+      inputRecord: countryDoc,
+      simplified: false
+    })
+
+    const result = await defaultApi.resources.countries.get({
+      id: `  ${countryId}  `,
+      simplified: false
+    })
+
+    validateJsonApiStructure(result)
+    assert.equal(result.data.id, countryId)
+    assert.equal(result.data.attributes.name, 'Canada')
+  })
+
+  it('lets a resource override the global normalizer', async () => {
+    const countryId = 'country-override'
+    const publisherId = 'publisher-override'
+    const countryDoc = createJsonApiDocument('countries', {
+      name: 'Spain'
+    })
+    countryDoc.data.id = countryId
+    const publisherDoc = createJsonApiDocument('publishers', {
+      name: 'Acme Press'
+    })
+    publisherDoc.data.id = publisherId
+
+    await overrideApi.resources.countries.post({
+      inputRecord: countryDoc,
+      simplified: false
+    })
+
+    await overrideApi.resources.publishers.post({
+      inputRecord: publisherDoc,
+      simplified: false
+    })
+
+    const countryResult = await overrideApi.resources.countries.get({
+      id: `  ${countryId.toUpperCase()}  `,
+      simplified: false
+    })
+
+    validateJsonApiStructure(countryResult)
+    assert.equal(countryResult.data.id, countryId)
+
+    const publisherResult = await overrideApi.resources.publishers.get({
+      id: `  ${publisherId}  `,
+      simplified: false
+    })
+
+    validateJsonApiStructure(publisherResult)
+    assert.equal(publisherResult.data.id, publisherId.toUpperCase())
+  })
+
+  it('normalizes explicit POST resource ids before persistence and return fetches', async () => {
+    const inputRecord = createJsonApiDocument('publishers', {
+      name: 'Explicit ID Press'
+    })
+    inputRecord.data.id = '  publisher-explicit  '
+
+    const result = await overrideApi.resources.publishers.post({
+      inputRecord,
+      simplified: false
+    })
+
+    assert.equal(result, undefined)
+
+    const inserted = await knex('id_norm_override_publishers')
+      .where({ id: 'PUBLISHER-EXPLICIT' })
+      .first()
+
+    assert.equal(inserted?.id, 'PUBLISHER-EXPLICIT')
+
+    const fetched = await overrideApi.resources.publishers.get({
+      id: 'publisher-explicit',
+      simplified: false
+    })
+
+    validateJsonApiStructure(fetched)
+    assert.equal(fetched.data.id, 'PUBLISHER-EXPLICIT')
+  })
+
+  it('normalizes belongsTo relationship ids using the related resource normalizer before persistence', async () => {
+    const countryRecord = createJsonApiDocument('countries', {
+      name: 'Spain'
+    })
+    countryRecord.data.id = 'country-1'
+
+    await overrideApi.resources.countries.post({
+      inputRecord: countryRecord,
+      simplified: false
+    })
+
+    const publisherRecord = createJsonApiDocument('publishers', {
+      name: 'Country Linked Press'
+    }, {
+      country: {
+        data: {
+          type: 'countries',
+          id: '  COUNTRY-1  '
+        }
+      }
+    })
+    publisherRecord.data.id = 'publisher-country'
+
+    await overrideApi.resources.publishers.post({
+      inputRecord: publisherRecord,
+      simplified: false
+    })
+
+    const inserted = await knex('id_norm_override_publishers')
+      .where({ id: 'PUBLISHER-COUNTRY' })
+      .first()
+
+    assert.equal(inserted?.country_id, 'country-1')
+  })
+
+  it('normalizes many-to-many relationship ids before pivot inserts and deletes', async () => {
+    const tagRecord = createJsonApiDocument('tags', {
+      name: 'Featured'
+    })
+    tagRecord.data.id = 'tag-1'
+
+    await overrideApi.resources.tags.post({
+      inputRecord: tagRecord,
+      simplified: false
+    })
+
+    const publisherRecord = createJsonApiDocument('publishers', {
+      name: 'Tagged Press'
+    })
+    publisherRecord.data.id = 'publisher-tags'
+
+    await overrideApi.resources.publishers.post({
+      inputRecord: publisherRecord,
+      simplified: false
+    })
+
+    await overrideApi.resources.publishers.postRelationship({
+      id: ' publisher-tags ',
+      relationshipName: 'tags',
+      relationshipData: [
+        {
+          type: 'tags',
+          id: '  TAG-1  '
+        }
+      ],
+      simplified: false
+    })
+
+    let pivotRows = await knex('id_norm_override_publisher_tags')
+      .where({ publisher_id: 'PUBLISHER-TAGS' })
+      .select('publisher_id', 'tag_id')
+
+    assert.deepEqual(pivotRows, [{
+      publisher_id: 'PUBLISHER-TAGS',
+      tag_id: 'tag-1'
+    }])
+
+    await overrideApi.resources.publishers.deleteRelationship({
+      id: 'publisher-tags',
+      relationshipName: 'tags',
+      relationshipData: [
+        {
+          type: 'tags',
+          id: ' TAG-1 '
+        }
+      ],
+      simplified: false
+    })
+
+    pivotRows = await knex('id_norm_override_publisher_tags')
+      .where({ publisher_id: 'PUBLISHER-TAGS' })
+      .select('publisher_id', 'tag_id')
+
+    assert.deepEqual(pivotRows, [])
+  })
+})


### PR DESCRIPTION
## Summary
- normalize JSON:API resource identifiers across core route handlers and relationship writes
- add shared resource id normalization support in the core query/write path
- add regression coverage for id normalization behavior

## Verification
- not run in this PR by request