### PR TITLE
Fix JSON:API cursor pagination for storage-mapped fields

### DIFF
--- a/plugins/core/lib/anyapi/utils/descriptor-helpers.js
+++ b/plugins/core/lib/anyapi/utils/descriptor-helpers.js
@@ -1,4 +1,5 @@
 import { RestApiValidationError } from '../../../../../lib/rest-api-errors.js'
+import { normalizeDateValue } from '../../querying-writing/database-value-normalizers.js'
 
 export const normalizeId = (value) => (value === null || value === undefined ? null : String(value))
 
@@ -88,6 +89,10 @@ export const coerceValueForDefinition = (value, definition, { isRelationship } =
 
   if (['string', 'text', 'uuid', 'email'].includes(type)) {
     return String(value)
+  }
+
+  if (['date', 'dateTime', 'time'].includes(type)) {
+    return normalizeDateValue(value, type)
   }
 
   return value

--- a/plugins/core/lib/querying-writing/database-value-normalizers.js
+++ b/plugins/core/lib/querying-writing/database-value-normalizers.js
@@ -48,7 +48,7 @@
  * 4. Handles MySQL datetime format (no T separator)
  * 5. Forces UTC interpretation to prevent timezone issues
  */
-function normalizeDateValue (value, type) {
+export function normalizeDateValue (value, type) {
   // Handle null/undefined
   if (value === null || value === undefined) {
     return null
@@ -81,25 +81,34 @@ function normalizeDateValue (value, type) {
 
   // Handle string values
   if (typeof value === 'string') {
+    const trimmed = value.trim()
+
+    if (/^-?\d+$/.test(trimmed)) {
+      const numericDate = new Date(Number(trimmed))
+      if (!isNaN(numericDate.getTime())) {
+        return numericDate
+      }
+    }
+
     // Detect MySQL datetime format: 'YYYY-MM-DD HH:MM:SS'
     // These have no T separator and no timezone indicator
     const isMySQLDateTime = type === 'dateTime' &&
-                           /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/.test(value) &&
-                           !value.includes('T') &&
-                           !value.includes('Z') &&
-                           !value.includes('+') &&
-                           !value.includes('-', 10) // Don't match date separators
+                           /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/.test(trimmed) &&
+                           !trimmed.includes('T') &&
+                           !trimmed.includes('Z') &&
+                           !trimmed.includes('+') &&
+                           !trimmed.includes('-', 10) // Don't match date separators
 
     if (isMySQLDateTime) {
       // Convert to ISO format and force UTC interpretation
       // '2024-01-15 10:30:00' becomes '2024-01-15T10:30:00Z'
-      return new Date(value.replace(' ', 'T') + 'Z')
+      return new Date(trimmed.replace(' ', 'T') + 'Z')
     }
 
     // For date-only fields, ensure parsing at UTC midnight
     // This prevents timezone shifts when parsing dates
-    if (type === 'date' && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
-      return new Date(value + 'T00:00:00Z')
+    if (type === 'date' && /^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+      return new Date(trimmed + 'T00:00:00Z')
     }
   }
 

--- a/plugins/core/lib/querying-writing/schema-helpers.js
+++ b/plugins/core/lib/querying-writing/schema-helpers.js
@@ -96,6 +96,36 @@ export function ensureSearchFieldsAreIndexed (searchSchema) {
   })
 }
 
+function createRelationshipSearchEntries (fieldName, fieldDef, searchEntry) {
+  if (!fieldDef?.belongsTo || !fieldDef?.as) {
+    return [[fieldName, searchEntry]]
+  }
+
+  const relationshipEntry = {
+    ...searchEntry,
+    actualField: fieldName,
+    isRelationship: true,
+    targetResource: fieldDef.belongsTo
+  }
+
+  return [
+    [fieldDef.as, relationshipEntry],
+    [fieldName, {
+      ...relationshipEntry
+    }]
+  ]
+}
+
+function registerSearchEntries (searchSchema, entries = []) {
+  for (const [searchFieldName, searchEntry] of entries) {
+    if (!searchFieldName || searchSchema[searchFieldName]) {
+      continue
+    }
+
+    searchSchema[searchFieldName] = searchEntry
+  }
+}
+
 /**
  * Generates complete searchSchema by merging schema search definitions with explicit searchSchema
  *
@@ -241,31 +271,12 @@ export const generateSearchSchemaFromSchema = (schema, explicitSearchSchema) => 
 
     if (effectiveSearch) {
       if (effectiveSearch === true) {
-        // For belongsTo relationships, use the relationship name (as property) instead of the field name
-        const searchFieldName = (fieldDef.belongsTo && fieldDef.as) ? fieldDef.as : fieldName
-
-        // Check if field already exists in explicit searchSchema
-        if (searchSchema[searchFieldName]) {
-          // Skip - explicit searchSchema takes precedence
-          // This allows searchSchema to override fields marked with search:true
-          return
-        }
-
         // Simple boolean - copy entire field definition (except search)
         const { search, ...fieldDefWithoutSearch } = fieldDef
-        const searchEntry = {
+        registerSearchEntries(searchSchema, createRelationshipSearchEntries(fieldName, fieldDef, {
           ...fieldDefWithoutSearch,
           // Do not set filterOperator here; centralized resolver will apply sensible defaults
-        }
-
-        // For belongsTo relationships, add metadata to map back to the actual field
-        if (fieldDef.belongsTo && fieldDef.as) {
-          searchEntry.actualField = fieldName  // Maps to the DB column
-          searchEntry.isRelationship = true
-          searchEntry.targetResource = fieldDef.belongsTo
-        }
-
-        searchSchema[searchFieldName] = searchEntry
+        }))
       } else if (typeof effectiveSearch === 'object') {
         // Check if search defines multiple filter fields
         const hasNestedFilters = Object.values(effectiveSearch).some(
@@ -288,29 +299,11 @@ export const generateSearchSchemaFromSchema = (schema, explicitSearchSchema) => 
             }
           })
         } else {
-          // For belongsTo relationships, use the relationship name (as property) instead of the field name
-          const searchFieldName = (fieldDef.belongsTo && fieldDef.as) ? fieldDef.as : fieldName
-
-          // Check if field already exists in explicit searchSchema
-          if (searchSchema[searchFieldName]) {
-            // Skip - explicit searchSchema takes precedence
-            return
-          }
-
           // Single filter with config
-          const searchEntry = {
+          registerSearchEntries(searchSchema, createRelationshipSearchEntries(fieldName, fieldDef, {
             type: fieldDef.type,
             ...effectiveSearch
-          }
-
-          // For belongsTo relationships, add metadata to map back to the actual field
-          if (fieldDef.belongsTo && fieldDef.as) {
-            searchEntry.actualField = fieldName  // Maps to the DB column
-            searchEntry.isRelationship = true
-            searchEntry.targetResource = fieldDef.belongsTo
-          }
-
-          searchSchema[searchFieldName] = searchEntry
+          }))
         }
       }
     }

--- a/plugins/core/lib/querying/knex-json-api-transformers-querying.js
+++ b/plugins/core/lib/querying/knex-json-api-transformers-querying.js
@@ -350,37 +350,42 @@ export const toJsonApiRecord = (scope, record, scopeName) => {
 export const buildJsonApiResponse = async (scope, records, included = [], isSingle = false, scopeName, context) => {
   const {
     vars: {
-      schemaInfo: { schemaInstance, schemaRelationships: relationships, idProperty }
+      schemaInfo
     }
   } = scope
 
-  const idField = idProperty || 'id'
+  const {
+    schemaInstance,
+    schemaRelationships: relationships
+  } = schemaInfo
 
   const schemaStructure = getSchemaStructure(schemaInstance)
 
   const processedRecords = records.map(record => {
     const { [RELATIONSHIPS_KEY]: _relationships, ...cleanRecord } = record
+    const logicalRecord = translateRecordFromStorage(cleanRecord, schemaInfo)
     const jsonApiRecord = toJsonApiRecord(scope, cleanRecord, scopeName)
+    const resourceId = jsonApiRecord.id
 
     if (_relationships) {
       jsonApiRecord.relationships = _relationships
     }
 
     for (const [fieldName, fieldDef] of Object.entries(schemaStructure)) {
-      if (fieldDef.belongsTo && fieldDef.as && fieldName in cleanRecord) {
+      if (fieldDef.belongsTo && fieldDef.as && fieldName in logicalRecord) {
         jsonApiRecord.relationships = jsonApiRecord.relationships || {}
         if (!jsonApiRecord.relationships[fieldDef.as]) {
-          if (cleanRecord[fieldName] !== null && cleanRecord[fieldName] !== undefined) {
+          if (logicalRecord[fieldName] !== null && logicalRecord[fieldName] !== undefined) {
             const relationshipObject = {
               data: {
                 type: fieldDef.belongsTo,
-                id: String(cleanRecord[fieldName])
+                id: String(logicalRecord[fieldName])
               }
             }
 
             relationshipObject.links = {
-              self: buildRelationshipUrl(context, scope, scopeName, record[idField], fieldDef.as, true),
-              related: buildRelationshipUrl(context, scope, scopeName, record[idField], fieldDef.as, false)
+              self: buildRelationshipUrl(context, scope, scopeName, resourceId, fieldDef.as, true),
+              related: buildRelationshipUrl(context, scope, scopeName, resourceId, fieldDef.as, false)
             }
 
             jsonApiRecord.relationships[fieldDef.as] = relationshipObject
@@ -390,8 +395,8 @@ export const buildJsonApiResponse = async (scope, records, included = [], isSing
             }
 
             relationshipObject.links = {
-              self: buildRelationshipUrl(context, scope, scopeName, record[idField], fieldDef.as, true),
-              related: buildRelationshipUrl(context, scope, scopeName, record[idField], fieldDef.as, false)
+              self: buildRelationshipUrl(context, scope, scopeName, resourceId, fieldDef.as, true),
+              related: buildRelationshipUrl(context, scope, scopeName, resourceId, fieldDef.as, false)
             }
 
             jsonApiRecord.relationships[fieldDef.as] = relationshipObject
@@ -402,8 +407,8 @@ export const buildJsonApiResponse = async (scope, records, included = [], isSing
 
     Object.entries(relationships || {}).forEach(([relName, relDef]) => {
       if (relDef.belongsToPolymorphic) {
-        const typeValue = cleanRecord[relDef.belongsToPolymorphic.typeField]
-        const idValue = cleanRecord[relDef.belongsToPolymorphic.idField]
+        const typeValue = logicalRecord[relDef.belongsToPolymorphic.typeField]
+        const idValue = logicalRecord[relDef.belongsToPolymorphic.idField]
 
         if (typeValue && idValue) {
           jsonApiRecord.relationships = jsonApiRecord.relationships || {}
@@ -415,8 +420,8 @@ export const buildJsonApiResponse = async (scope, records, included = [], isSing
           }
 
           relationshipObject.links = {
-            self: buildRelationshipUrl(context, scope, scopeName, record[idField], relName, true),
-            related: buildRelationshipUrl(context, scope, scopeName, record[idField], relName, false)
+            self: buildRelationshipUrl(context, scope, scopeName, resourceId, relName, true),
+            related: buildRelationshipUrl(context, scope, scopeName, resourceId, relName, false)
           }
 
           jsonApiRecord.relationships[relName] = relationshipObject
@@ -427,8 +432,8 @@ export const buildJsonApiResponse = async (scope, records, included = [], isSing
           }
 
           relationshipObject.links = {
-            self: buildRelationshipUrl(context, scope, scopeName, record[idField], relName, true),
-            related: buildRelationshipUrl(context, scope, scopeName, record[idField], relName, false)
+            self: buildRelationshipUrl(context, scope, scopeName, resourceId, relName, true),
+            related: buildRelationshipUrl(context, scope, scopeName, resourceId, relName, false)
           }
 
           jsonApiRecord.relationships[relName] = relationshipObject

--- a/plugins/core/lib/querying/knex-pagination-helpers.js
+++ b/plugins/core/lib/querying/knex-pagination-helpers.js
@@ -1,3 +1,5 @@
+import { getFieldValue } from '../storage/storage-mapping.js'
+
 /**
  * Calculates pagination metadata from query results
  *
@@ -257,11 +259,13 @@ export const generatePaginationLinks = (urlPrefix, scopeName, queryParams, pagin
  * 4. Cursor used in 'next' link for fetching subsequent pages
  * 5. Enables efficient "WHERE (field1, field2) > (val1, val2)" queries
  */
-export const createCursor = (record, sortFields = ['id']) => {
+export const createCursor = (record, sortFields = ['id'], { schemaInfo = null } = {}) => {
   const parts = []
   sortFields.forEach(field => {
-    if (record[field] !== undefined) {
-      const value = record[field]
+    const value = schemaInfo
+      ? getFieldValue(record, schemaInfo, field)
+      : record[field]
+    if (value !== undefined) {
       const stringValue = value instanceof Date ? value.toISOString() : String(value)
       parts.push(`${field}:${encodeURIComponent(stringValue)}`)
     }
@@ -427,7 +431,16 @@ export const parseCursor = (cursor) => {
  * 4. Added to response.links for navigation
  * 5. Client uses next link to fetch subsequent pages
  */
-export const generateCursorPaginationLinks = (urlPrefix, scopeName, queryParams, records, pageSize, hasMore, sortFields = ['id']) => {
+export const generateCursorPaginationLinks = (
+  urlPrefix,
+  scopeName,
+  queryParams,
+  records,
+  pageSize,
+  hasMore,
+  sortFields = ['id'],
+  { schemaInfo = null } = {}
+) => {
   // Allow empty urlPrefix to generate relative links
   if (!records.length) return null
 
@@ -479,7 +492,7 @@ export const generateCursorPaginationLinks = (urlPrefix, scopeName, queryParams,
 
   if (hasMore && records.length > 0) {
     const lastRecord = records[records.length - 1]
-    const nextCursor = createCursor(lastRecord, sortFields)
+    const nextCursor = createCursor(lastRecord, sortFields, { schemaInfo })
     links.next = `${baseUrl}${queryPrefix}page[size]=${pageSize}&page[after]=${nextCursor}`
   }
 
@@ -543,7 +556,7 @@ export const generateCursorPaginationLinks = (urlPrefix, scopeName, queryParams,
  * 3. Added to response.meta.pagination
  * 4. Clients can use cursor directly or use the next link
  */
-export const buildCursorMeta = (records, pageSize, hasMore, sortFields = ['id']) => {
+export const buildCursorMeta = (records, pageSize, hasMore, sortFields = ['id'], { schemaInfo = null } = {}) => {
   const meta = {
     pageSize,
     hasMore
@@ -552,7 +565,7 @@ export const buildCursorMeta = (records, pageSize, hasMore, sortFields = ['id'])
   if (hasMore && records.length > 0) {
     const lastRecord = records[records.length - 1]
     meta.cursor = {
-      next: createCursor(lastRecord, sortFields)
+      next: createCursor(lastRecord, sortFields, { schemaInfo })
     }
   }
 

--- a/plugins/core/lib/storage/storage-adapter.js
+++ b/plugins/core/lib/storage/storage-adapter.js
@@ -9,6 +9,7 @@ import {
   getCanonicalResourceIdColumn,
   translateCanonicalAttributesForStorage,
 } from './canonical-storage-mapping.js'
+import { normalizeDateValue } from '../querying-writing/database-value-normalizers.js'
 
 const passthrough = (value) => value
 const identityTranslate = (_field, value) => value
@@ -32,6 +33,54 @@ const normalizeBelongsToValue = (value) => {
     return normalizeArray(value, normalizeBelongsToValue)
   }
   return String(value)
+}
+
+const normalizeBooleanValue = (value) => {
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (normalized === 'true' || normalized === '1') return true
+    if (normalized === 'false' || normalized === '0') return false
+  }
+  if (typeof value === 'number') {
+    if (value === 1) return true
+    if (value === 0) return false
+  }
+  return Boolean(value)
+}
+
+const normalizeFilterValueForDefinition = (value, definition = {}, { isRelationship = false } = {}) => {
+  if (value === null || value === undefined) return value
+  if (Array.isArray(value)) {
+    return normalizeArray(
+      value,
+      (entry) => normalizeFilterValueForDefinition(entry, definition, { isRelationship })
+    )
+  }
+
+  if (isRelationship) {
+    return normalizeBelongsToValue(value)
+  }
+
+  const type = definition?.type || definition?.dataType
+  if (!type) {
+    return value
+  }
+
+  if (['number', 'integer', 'float', 'decimal'].includes(type)) {
+    const numeric = Number(value)
+    return Number.isNaN(numeric) ? value : numeric
+  }
+
+  if (type === 'boolean') {
+    return normalizeBooleanValue(value)
+  }
+
+  if (['date', 'dateTime', 'time'].includes(type)) {
+    return normalizeDateValue(value, type)
+  }
+
+  return value
 }
 
 const translateSourceColumn = (source, adapter) => {
@@ -124,13 +173,24 @@ const createLegacyAdapter = ({ knex, schemaInfo }) => {
   const translateColumn = (field) => getStorageColumn(schemaInfo, field)
   const toStorageRow = (attributes, options = {}) => translateAttributesForStorage(attributes, schemaInfo, options)
   const getFieldValue = (record, fieldName) => getLegacyFieldValue(record, schemaInfo, fieldName)
+  const translateFilterValue = (field, value) => {
+    const searchField = schemaInfo.searchSchemaStructure?.[field]
+    const schemaField = schemaInfo.schemaStructure?.[field]
+    const definition = searchField || schemaField || {}
+    const isRelationship = Boolean(
+      searchField?.isRelationship ||
+      schemaField?.belongsTo ||
+      schemaField?.belongsToPolymorphic
+    )
+    return normalizeFilterValueForDefinition(value, definition, { isRelationship })
+  }
 
   return baseAdapter({
     knex,
     tableName,
     idColumn,
     translateColumn,
-    translateFilterValue: identityTranslate,
+    translateFilterValue,
     applyResourceScope: identityScope,
     toStorageRow,
     getFieldValue,
@@ -183,8 +243,6 @@ const createCanonicalAdapter = ({ knex, schemaInfo }) => {
   }
 
   const translateFilterValue = (field, value) => {
-    if (value === null || value === undefined) return value
-
     const searchField = schemaInfo.searchSchemaStructure?.[field]
     const schemaField = schemaInfo.schemaStructure?.[field]
     const isRelationship = Boolean(
@@ -192,15 +250,9 @@ const createCanonicalAdapter = ({ knex, schemaInfo }) => {
       schemaField?.belongsTo ||
       schemaField?.belongsToPolymorphic
     )
+    const definition = searchField || schemaField || {}
 
-    if (!isRelationship) {
-      if (Array.isArray(value)) {
-        return normalizeArray(value, passthrough)
-      }
-      return value
-    }
-
-    return normalizeBelongsToValue(value)
+    return normalizeFilterValueForDefinition(value, definition, { isRelationship })
   }
 
   const applyResourceScope = (query) => {

--- a/plugins/core/rest-api-anyapi-knex-plugin.js
+++ b/plugins/core/rest-api-anyapi-knex-plugin.js
@@ -379,13 +379,16 @@ export const RestApiAnyapiKnexPlugin = {
 
         predicateChains.forEach((chain) => {
           const chainParts = chain.map(({ descriptor, operator, value }) => {
+            const normalizedValue = adapter?.translateFilterValue
+              ? adapter.translateFilterValue(descriptor.field, value)
+              : value
             if (descriptor.queryFieldRuntime) {
-              predicateBindings.push(...(descriptor.queryFieldRuntime.bindings || []), value)
+              predicateBindings.push(...(descriptor.queryFieldRuntime.bindings || []), normalizedValue)
               return `(${descriptor.queryFieldRuntime.sql}) ${operator} ?`
             }
 
             const columnRef = adapter ? adapter.translateColumn(descriptor.column) : descriptor.column
-            predicateBindings.push(value)
+            predicateBindings.push(normalizedValue)
             return `${columnRef} ${operator} ?`
           })
 
@@ -2215,7 +2218,10 @@ export const RestApiAnyapiKnexPlugin = {
           cursorRecords,
           paginationInfo.pageSize,
           hasMore,
-          cursorFields
+          cursorFields,
+          {
+            schemaInfo
+          }
         )
         context.returnMeta.paginationMeta = paginationMeta
         const urlPrefix = getUrlPrefix(context, scope)
@@ -2226,7 +2232,10 @@ export const RestApiAnyapiKnexPlugin = {
           cursorRecords,
           paginationInfo.pageSize,
           hasMore,
-          cursorFields
+          cursorFields,
+          {
+            schemaInfo
+          }
         )
       }
 

--- a/plugins/core/rest-api-knex-plugin.js
+++ b/plugins/core/rest-api-knex-plugin.js
@@ -708,7 +708,13 @@ export const RestApiKnexPlugin = {
               sortDescriptors,
               cursorData,
               (direction) => (direction === 'DESC' ? '<' : '>'),
-              (builder, descriptor, operator, value) => builder.where(descriptor.column, operator, value),
+              (builder, descriptor, operator, value) => builder.where(
+                descriptor.column,
+                operator,
+                storageAdapter?.translateFilterValue
+                  ? storageAdapter.translateFilterValue(descriptor.field, value)
+                  : value
+              ),
               {
                 onMissingValue: (fieldName) => log.warn(`Cursor missing value for sort field: ${fieldName}`)
               }
@@ -736,7 +742,13 @@ export const RestApiKnexPlugin = {
               sortDescriptors,
               cursorData,
               (direction) => (direction === 'DESC' ? '>' : '<'),
-              (builder, descriptor, operator, value) => builder.where(descriptor.column, operator, value),
+              (builder, descriptor, operator, value) => builder.where(
+                descriptor.column,
+                operator,
+                storageAdapter?.translateFilterValue
+                  ? storageAdapter.translateFilterValue(descriptor.field, value)
+                  : value
+              ),
               {
                 onMissingValue: (fieldName) => log.warn(`Cursor missing value for sort field: ${fieldName}`)
               }
@@ -863,7 +875,9 @@ export const RestApiKnexPlugin = {
 
         const sortFields = sortDescriptors.map((descriptor) => descriptor.field)
 
-        context.returnMeta.paginationMeta = buildCursorMeta(records, pageSize, hasMore, sortFields)
+        context.returnMeta.paginationMeta = buildCursorMeta(records, pageSize, hasMore, sortFields, {
+          schemaInfo
+        })
         const urlPrefix = getUrlPrefix(context, scope)
         context.returnMeta.paginationLinks = generateCursorPaginationLinks(
           urlPrefix,
@@ -872,7 +886,10 @@ export const RestApiKnexPlugin = {
           records,
           pageSize,
           hasMore,
-          sortFields
+          sortFields,
+          {
+            schemaInfo
+          }
         )
       }
 

--- a/tests/fixtures/api-configs.js
+++ b/tests/fixtures/api-configs.js
@@ -1900,7 +1900,7 @@ export async function createCursorPaginationApi (knex) {
       put: 'full',
       patch: 'minimal'
     },
-    sortableFields: ['id', 'name', 'category', 'brand', 'price', 'sku', 'created_at', 'code', 'status', 'type'],
+    sortableFields: ['id', 'name', 'category', 'brand', 'price', 'sku', 'createdAt', 'code', 'status', 'type'],
     queryDefaultLimit: 20,
     queryMaxLimit: 100,
     returnBasePath: 'https://api.example.com'
@@ -1920,7 +1920,7 @@ export async function createCursorPaginationApi (knex) {
       price: { type: 'number', required: true },
       sku: { type: 'string', required: true, max: 50, unique: true },
       status: { type: 'string', max: 50, default: 'active' },
-      created_at: { type: 'dateTime', default: 'now()' }
+      createdAt: { type: 'dateTime', default: 'now()' }
     },
     tableName: 'cursor_products'
   })

--- a/tests/fixtures/api-configs.js
+++ b/tests/fixtures/api-configs.js
@@ -199,6 +199,59 @@ export async function createBasicApi (knex, pluginOptions = {}) {
 }
 
 /**
+ * Creates a small API that uses logical camelCase belongsTo fields with default snake_case storage mapping.
+ * This reproduces the full JSON:API linkage path where storage column names differ from logical field names.
+ */
+export async function createCamelCaseBelongsToApi (knex, pluginOptions = {}) {
+  const apiName = pluginOptions.apiName || 'camelcase-belongsto-test-api'
+  const tablePrefix = pluginOptions.tablePrefix || 'camel_fk'
+
+  const api = new Api({
+    name: apiName,
+    log: { level: process.env.LOG_LEVEL || 'info' }
+  })
+
+  await api.use(RestApiPlugin, {
+    simplifiedApi: false,
+    simplifiedTransport: false,
+    returnRecordApi: {
+      post: true,
+      put: false,
+      patch: false
+    },
+    returnRecordTransport: {
+      post: 'full',
+      put: 'no',
+      patch: 'full'
+    },
+    ...(pluginOptions['rest-api'] || {})
+  })
+
+  await api.use(RestApiKnexPlugin, { knex })
+
+  await api.addResource('countries', {
+    schema: {
+      id: { type: 'id' },
+      name: { type: 'string', required: true, max: 100 }
+    },
+    tableName: `${tablePrefix}_countries`
+  })
+  await api.resources.countries.createKnexTable()
+
+  await api.addResource('publishers', {
+    schema: {
+      id: { type: 'id' },
+      name: { type: 'string', required: true, max: 200 },
+      countryId: { type: 'number', nullable: true, belongsTo: 'countries', as: 'country' }
+    },
+    tableName: `${tablePrefix}_publishers`
+  })
+  await api.resources.publishers.createKnexTable()
+
+  return api
+}
+
+/**
  * Creates a small API focused on resource ID normalization behavior.
  */
 export async function createIdNormalizationApi (knex, pluginOptions = {}) {

--- a/tests/full-jsonapi-belongsto-linkage.test.js
+++ b/tests/full-jsonapi-belongsto-linkage.test.js
@@ -1,0 +1,148 @@
+import { after, before, beforeEach, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import knexLib from 'knex'
+import { createCamelCaseBelongsToApi } from './fixtures/api-configs.js'
+import {
+  createJsonApiDocument,
+  createRelationship,
+  resourceIdentifier,
+  assertResourceRelationship
+} from './helpers/test-utils.js'
+
+const knex = knexLib({
+  client: 'better-sqlite3',
+  connection: {
+    filename: ':memory:'
+  },
+  useNullAsDefault: true
+})
+
+let api
+
+describe('Full JSON:API belongsTo linkage', () => {
+  before(async () => {
+    api = await createCamelCaseBelongsToApi(knex)
+  })
+
+  after(async () => {
+    await knex.destroy()
+  })
+
+  beforeEach(async () => {
+    await knex('camel_fk_publishers').delete()
+    await knex('camel_fk_countries').delete()
+  })
+
+  const createCountry = async () => {
+    return api.resources.countries.post({
+      inputRecord: createJsonApiDocument('countries', {
+        name: 'United States'
+      }),
+      simplified: false
+    })
+  }
+
+  const createPublisher = async (countryId = null) => {
+    return api.resources.publishers.post({
+      inputRecord: createJsonApiDocument(
+        'publishers',
+        { name: 'Mapped Publisher' },
+        {
+          country: createRelationship(
+            countryId == null ? null : resourceIdentifier('countries', countryId)
+          )
+        }
+      ),
+      simplified: false
+    })
+  }
+
+  it('emits belongsTo linkage on primary resources without include for single and collection responses', async () => {
+    const country = await createCountry()
+    const publisher = await createPublisher(country.data.id)
+
+    assertResourceRelationship(
+      publisher.data,
+      'country',
+      resourceIdentifier('countries', country.data.id)
+    )
+    assert.equal(Object.hasOwn(publisher.data.attributes, 'countryId'), false)
+
+    const single = await api.resources.publishers.get({
+      id: publisher.data.id,
+      simplified: false
+    })
+
+    assertResourceRelationship(
+      single.data,
+      'country',
+      resourceIdentifier('countries', country.data.id)
+    )
+    assert.equal(Object.hasOwn(single.data.attributes, 'countryId'), false)
+
+    const collection = await api.resources.publishers.query({
+      simplified: false
+    })
+
+    assert.equal(collection.data.length, 1)
+    assertResourceRelationship(
+      collection.data[0],
+      'country',
+      resourceIdentifier('countries', country.data.id)
+    )
+    assert.equal(Object.hasOwn(collection.data[0].attributes, 'countryId'), false)
+  })
+
+  it('keeps primary belongsTo linkage when include is requested and adds included resources', async () => {
+    const country = await createCountry()
+    const publisher = await createPublisher(country.data.id)
+
+    const result = await api.resources.publishers.get({
+      id: publisher.data.id,
+      queryParams: {
+        include: ['country']
+      },
+      simplified: false
+    })
+
+    assertResourceRelationship(
+      result.data,
+      'country',
+      resourceIdentifier('countries', country.data.id)
+    )
+    assert.equal(Object.hasOwn(result.data.attributes, 'countryId'), false)
+    assert.equal(result.included?.length, 1)
+    assert.equal(result.included?.[0]?.type, 'countries')
+    assert.equal(result.included?.[0]?.id, country.data.id)
+  })
+
+  it('emits explicit null belongsTo linkage without exposing the foreign key attribute', async () => {
+    const country = await createCountry()
+    const publisher = await createPublisher(country.data.id)
+
+    const patched = await api.resources.publishers.patch({
+      id: publisher.data.id,
+      inputRecord: {
+        data: {
+          type: 'publishers',
+          id: publisher.data.id,
+          relationships: {
+            country: { data: null }
+          }
+        }
+      },
+      simplified: false
+    })
+
+    assert.equal(patched.data.relationships?.country?.data, null)
+    assert.equal(Object.hasOwn(patched.data.attributes, 'countryId'), false)
+
+    const single = await api.resources.publishers.get({
+      id: publisher.data.id,
+      simplified: false
+    })
+
+    assert.equal(single.data.relationships?.country?.data, null)
+    assert.equal(Object.hasOwn(single.data.attributes, 'countryId'), false)
+  })
+})

--- a/tests/pagination-cursor-multifield.test.js
+++ b/tests/pagination-cursor-multifield.test.js
@@ -222,6 +222,76 @@ describe('Multi-field Cursor Pagination', () => {
         'Prices should be non-decreasing across pages')
     })
 
+    it('should advance when sorting by logical camelCase fields backed by snake_case storage columns', async () => {
+      await cleanTables(knex, ['cursor_products'])
+
+      const products = [
+        {
+          name: 'Newest Product',
+          category: 'Catalog',
+          brand: 'Acme',
+          price: 10,
+          sku: 'CAMEL-001',
+          createdAt: '2026-05-03T10:00:00.000Z'
+        },
+        {
+          name: 'Recent Product',
+          category: 'Catalog',
+          brand: 'Acme',
+          price: 20,
+          sku: 'CAMEL-002',
+          createdAt: '2026-05-03T09:00:00.000Z'
+        },
+        {
+          name: 'Older Product',
+          category: 'Catalog',
+          brand: 'Acme',
+          price: 30,
+          sku: 'CAMEL-003',
+          createdAt: '2026-05-03T08:00:00.000Z'
+        }
+      ]
+
+      for (const product of products) {
+        await api.resources.products.post({
+          inputRecord: createJsonApiDocument('products', product),
+          simplified: false
+        })
+      }
+
+      const firstPage = await api.resources.products.query({
+        queryParams: {
+          page: { size: 2 },
+          sort: ['-createdAt']
+        },
+        simplified: false
+      })
+
+      assert.equal(firstPage.data.length, 2)
+      assert.equal(firstPage.meta.pagination.cursor?.next.includes('createdAt:'), true,
+        'Cursor should include the logical createdAt field')
+
+      const secondPage = await api.resources.products.query({
+        queryParams: {
+          page: {
+            size: 2,
+            after: firstPage.meta.pagination.cursor.next
+          },
+          sort: ['-createdAt']
+        },
+        simplified: false
+      })
+
+      assert.deepEqual(
+        firstPage.data.map((record) => record.attributes.name),
+        ['Newest Product', 'Recent Product']
+      )
+      assert.deepEqual(
+        secondPage.data.map((record) => record.attributes.name),
+        ['Older Product']
+      )
+    })
+
     it('should generate correct cursor values for multi-field sorting', async () => {
       const result = await api.resources.products.query({
         queryParams: {

--- a/tests/searchschema-merge.test.js
+++ b/tests/searchschema-merge.test.js
@@ -5,6 +5,7 @@ import {
   cleanTables,
 } from './helpers/test-utils.js'
 import { createSearchSchemaMergeApi } from './fixtures/api-configs.js'
+import { generateSearchSchemaFromSchema } from '../plugins/core/lib/querying-writing/schema-helpers.js'
 
 // Create Knex instance for tests - always use SQLite in-memory
 const knex = knexLib({
@@ -130,5 +131,21 @@ describe('SearchSchema Merge Behavior', () => {
       (error) => error?.code === 'REST_API_VALIDATION',
       'Should reject fields that are not defined in searchSchema'
     )
+  })
+
+  it('should keep canonical belongsTo field keys searchable alongside relationship aliases', () => {
+    const searchSchema = generateSearchSchemaFromSchema({
+      petId: {
+        type: 'id',
+        belongsTo: 'pets',
+        as: 'pet',
+        search: true
+      }
+    }, null)
+
+    assert.ok(searchSchema.pet, 'relationship alias should stay searchable')
+    assert.equal(searchSchema.pet.actualField, 'petId')
+    assert.ok(searchSchema.petId, 'canonical field key should stay searchable for parent filters')
+    assert.equal(searchSchema.petId.actualField, 'petId')
   })
 })

--- a/tests/storage-mapping.test.js
+++ b/tests/storage-mapping.test.js
@@ -42,6 +42,7 @@ describe('Storage mapping', () => {
     await api.use(RestApiPlugin, {
       simplifiedApi: false,
       simplifiedTransport: false,
+      sortableFields: ['id', 'displayName', 'loginCount', 'lastSeenAt', 'countryId', 'externalRef'],
       returnRecordApi: {
         post: 'full',
         put: 'full',


### PR DESCRIPTION
## Summary
- emit primary belongs-to linkage in full JSON:API mode from the current branch state
- fix cursor generation for logical sort fields backed by storage-mapped columns
- normalize cursor predicate values so load-more advances correctly for MySQL date/time sorts
- add regression coverage for storage-mapped cursor pagination

## Verification
- node --test tests/pagination-cursor-multifield.test.js tests/pagination-enhanced.test.js tests/storage-mapping.test.js
- live API pagination checks for contacts/products page 1 -> page 2
- browser checks confirming "Load more" appends new rows in contacts and products

## Notes
- Per request, I did not run `npm verify`.
