### PR TITLE
Fix AnyAPI custom idProperty mapping

### DIFF
--- a/fixing_plan.md
+++ b/fixing_plan.md
@@ -1,0 +1,112 @@
+# Fixing Plan
+
+Checklist-style plan for addressing the audit findings. Items marked as requiring approval change public behavior, public API, or dependencies.
+
+## High Priority
+
+- [x] Fix AnyAPI custom `idProperty` canonical mapping.
+  - [x] Treat `schemaInfo.idProperty` as an alias of logical `id` in the canonical storage adapter.
+  - [x] Skip custom id fields such as `item_id` when building DB attribute selections.
+  - [x] Ensure cursor, sort, projection, sparse fieldset, and include paths translate both `id` and `idProperty` to `logical_id`.
+  - [x] Add AnyAPI tests for custom-id `post`, `get`, `query`, sparse fields, and cursor pagination.
+
+- [ ] Fix AnyAPI PUT create parity.
+  - [ ] Branch `helpers.dataPut` on `context.isCreate`.
+  - [ ] In create mode, insert into `any_records` with tenant, resource, logical id, and translated attributes.
+  - [ ] Keep the current update path for update mode.
+  - [ ] Add legacy Knex and AnyAPI parity tests for `PUT /resource/:id` create, including custom IDs.
+
+- [ ] Fix pagination link query-string round trips.
+  - [ ] Replace manual query-string concatenation with one serializer that is the inverse of `parseJsonApiQuery`.
+  - [ ] Use `URLSearchParams` for keys and values.
+  - [ ] Map internal `queryParams.filters` back to public JSON:API `filter[...]`.
+  - [ ] Add tests that parse generated `links.next` and prove filters, fields, sort, include, and page params survive round trip.
+
+- [ ] Fix relationship PATCH cardinality validation.
+  - [ ] Generate relationship-aware request contracts from relationship metadata.
+  - [ ] Allow to-one relationship PATCH data to be `null` or one resource identifier only.
+  - [ ] Allow to-many relationship data to be arrays only.
+  - [ ] Make `processRelationships()` throw when a belongsTo relationship receives an array.
+  - [ ] Add API and transport tests for invalid to-one arrays and invalid to-many scalars.
+
+- [ ] Run `afterCommit` for relationship routes.
+  - [ ] After `postRelationship`, `patchRelationship`, and `deleteRelationship` commit their own transaction, run `afterCommit`.
+  - [ ] Preserve rollback behavior through `afterRollback`.
+  - [ ] Verify Socket.IO deferred relationship broadcasts work, or define a separate relationship notification policy.
+  - [ ] Add tests with an `afterCommit` hook counter and Socket.IO relationship-write subscription behavior.
+
+- [ ] Decide and fix post-commit hook failure semantics. Requires maintainer approval.
+  - [ ] Split transaction work from post-commit side effects.
+  - [ ] Once `commit()` succeeds, do not call rollback handling.
+  - [ ] Decide whether post-commit hook errors are surfaced distinctly or logged/collected while returning success.
+  - [ ] Add tests proving the row remains committed and the response/error semantics are intentional.
+
+## Medium Priority
+
+- [ ] Fix AnyAPI pagination fixture cleanup.
+  - [ ] Register `cursor_products` and `cursor_items` with `storageMode.registerTable()` in `createCursorPaginationApi`.
+  - [ ] Add a focused cleanup test proving `cleanTables(knex, ['cursor_products'])` deletes matching `any_records`.
+  - [ ] Consider deriving AnyAPI cleanup mappings from API metadata later if a broader helper refactor is approved.
+
+- [ ] Fix file temp and orphan cleanup.
+  - [ ] Wrap file processing in `try/finally` so detector temp files are cleaned after validation failures.
+  - [ ] Track successfully uploaded URLs on `context`.
+  - [ ] On rollback or later write error, call storage `delete(url)` where available.
+  - [ ] Document `delete(url)` as the rollback-capable storage contract.
+  - [ ] Add tests for invalid MIME cleanup and post-upload DB/validation rollback cleanup.
+
+- [ ] Harden `LocalStorage` path containment.
+  - [ ] Sanitize or reject custom basenames containing `/`, `\`, drive prefixes, or empty names.
+  - [ ] Replace `startsWith(resolvedDir)` containment with `path.relative(resolvedDir, resolvedPath)`.
+  - [ ] Add tests for sibling-prefix traversal such as `../uploads_evil/pwn`.
+
+- [ ] Fix untrusted proxy URL generation. Requires maintainer approval.
+  - [ ] Stop trusting `Host` and `X-Forwarded-*` by default for absolute links.
+  - [ ] Prefer relative links unless `urlPrefixOverride` or an explicit public base URL is configured.
+  - [ ] If forwarded headers remain supported, gate them behind `trustProxy` and allowed host/proto validation.
+  - [ ] Add Express and Fastify tests with hostile `Host` and `X-Forwarded-Host` headers.
+
+- [ ] Fix `S3Storage` non-mock behavior. Dependency/public behavior choice requires maintainer approval.
+  - [ ] Smallest safe fix: throw a clear "real S3 storage is not implemented" error when `mockMode: false`.
+  - [ ] Full fix option: add AWS SDK support and real upload/delete implementation.
+  - [ ] Add tests for mock mode and the chosen non-mock behavior.
+
+## Low Priority
+
+- [ ] Make field setter errors fail closed.
+  - [ ] Change setter error handling to throw by default.
+  - [ ] Add an explicit opt-in non-fatal mode only if there is a real use case.
+  - [ ] Add a rollback test where a setter throws and no row is persisted.
+
+- [ ] Normalize return-record boolean compatibility.
+  - [ ] Create one shared return-record normalizer.
+  - [ ] Normalize `true -> 'full'`, `false -> 'no'`, and keep valid strings unchanged.
+  - [ ] Use the shared normalizer in plugin install and per-call setup.
+  - [ ] Update tests and docs to prefer `'no'`, `'minimal'`, and `'full'` while preserving boolean compatibility.
+
+## Contract Drift
+
+- [ ] Fix Socket.IO public exports and docs.
+  - [ ] Export `SocketIOPlugin` from `index.js`.
+  - [ ] Fix docs to import `Api` from `hooked-api`, not `json-rest-api`.
+  - [ ] Remove invalid deep imports such as `json-rest-api/plugins/socketio`, or add formal package subpath exports. Subpath exports require maintainer approval.
+  - [ ] Add a public import smoke test.
+
+- [ ] Align S3 documentation with implementation.
+  - [ ] If real S3 is not implemented, make README and guide text state that the included adapter is mock/demo only.
+  - [ ] If real S3 is implemented, update docs and tests to match the production behavior.
+
+- [ ] Finish relationship validation contract consolidation.
+  - [ ] Move relationship-route schemas into the same request-contract surface as resource routes.
+  - [ ] Do this after the cardinality fix so the centralized contract is correct rather than merely centralized.
+
+## Verification Checklist
+
+- [ ] `npm test`
+- [ ] `npm run lint`
+- [ ] `npm run test:anyapi`
+- [ ] `npm run verify`
+- [x] Narrow repro for AnyAPI custom `idProperty`
+- [ ] Narrow repro for relationship route `afterCommit`
+- [ ] Narrow repro for pagination link round trip
+- [ ] Import smoke test for public exports

--- a/plugins/core/lib/anyapi/anyapi-registry.js
+++ b/plugins/core/lib/anyapi/anyapi-registry.js
@@ -9,6 +9,21 @@ const clone = (value) => {
 
 const SUPPORTED_TYPES = new Set([...TYPE_TO_POOL.keys(), 'id'])
 
+const resolveIdProperty = (schema = {}, explicitIdProperty = null) => {
+  if (explicitIdProperty) return explicitIdProperty
+  if (schema.id) return 'id'
+
+  const idFields = Object.entries(schema)
+    .filter(([, fieldDef]) => (
+      fieldDef?.type === 'id' &&
+      !fieldDef.belongsTo &&
+      !fieldDef.belongsToPolymorphic
+    ))
+    .map(([fieldName]) => fieldName)
+
+  return idFields.length === 1 ? idFields[0] : 'id'
+}
+
 const BELONGS_TO_ALIAS = (fieldName, fieldDef) => {
   if (fieldDef.as) return fieldDef.as
   if (fieldName.endsWith('_id')) {
@@ -305,6 +320,7 @@ export class AnyapiRegistry {
 
   async #register (definition, externalTrx) {
     const { tenant, resource, schema, relationships = {}, canonicalFieldMap = null } = definition
+    const idProperty = resolveIdProperty(schema, definition.idProperty)
     const trx = externalTrx || await this.knex.transaction()
     const managed = !externalTrx
 
@@ -520,7 +536,7 @@ export class AnyapiRegistry {
         await trx('any_relationship_configs').insert(relationshipInserts)
       }
 
-      const descriptor = await this.#loadDescriptor(tenant, resource, trx)
+      const descriptor = await this.#loadDescriptor(tenant, resource, trx, { idProperty })
 
       if (managed) {
         await trx.commit()
@@ -535,7 +551,7 @@ export class AnyapiRegistry {
     }
   }
 
-  async #loadDescriptor (tenant, resource, trx) {
+  async #loadDescriptor (tenant, resource, trx, options = {}) {
     const query = (trx || this.knex)('any_resource_configs')
       .where({ tenant_id: tenant, resource })
       .first()
@@ -568,6 +584,7 @@ export class AnyapiRegistry {
       slotState,
       fieldRows,
       relationshipRows,
+      idProperty: options.idProperty,
     })
 
     const canonicalFieldMap = {}
@@ -589,7 +606,7 @@ export class AnyapiRegistry {
     return descriptor
   }
 
-  #buildDescriptor ({ tenant, resource, schema, relationships, slotState, fieldRows, relationshipRows }) {
+  #buildDescriptor ({ tenant, resource, schema, relationships, slotState, fieldRows, relationshipRows, idProperty }) {
     const fields = {}
     const reverseAttributes = {}
     const belongsTo = {}
@@ -671,6 +688,7 @@ export class AnyapiRegistry {
     return {
       tenant,
       resource,
+      idProperty: resolveIdProperty(schema, idProperty),
       schema,
       relationships,
       canonical: DEFAULT_CANONICAL_CONFIG,

--- a/plugins/core/lib/anyapi/utils/descriptor-helpers.js
+++ b/plugins/core/lib/anyapi/utils/descriptor-helpers.js
@@ -22,7 +22,8 @@ export const findSchemaFieldByAlias = (descriptor, alias) => {
 
 export const resolveFieldInfo = (descriptor, field) => {
   if (!descriptor) return null
-  if (field === 'id') {
+  const idProperty = descriptor.idProperty || 'id'
+  if (field === 'id' || field === idProperty) {
     return {
       column: descriptor?.canonical?.logicalIdColumn || 'logical_id',
       definition: { type: 'id' }

--- a/plugins/core/lib/querying-writing/knex-field-helpers.js
+++ b/plugins/core/lib/querying-writing/knex-field-helpers.js
@@ -150,7 +150,8 @@ export const buildFieldSelection = async (scope, deps) => {
   const scopeSchemaInfo = scope?.vars?.schemaInfo || {}
   const {
     schemaInstance,
-    computed: computedFields = {}
+    computed: computedFields = {},
+    idProperty = 'id'
   } = scopeSchemaInfo
   let schemaStructure = scopeSchemaInfo.schemaStructure
   const queryFields = scope?.vars?.queryFields || {}
@@ -196,6 +197,8 @@ export const buildFieldSelection = async (scope, deps) => {
     // Sparse fieldsets requested - only select specified fields
     // Example: ?fields[products]=name,price,profit_margin
     requested.forEach(field => {
+      if (field === 'id' || field === idProperty) return
+
       if (queryFieldNames.has(field)) {
         if (queryFields[field]?.hidden === true) return
         queryFieldsToSelect.add(field)
@@ -261,6 +264,8 @@ export const buildFieldSelection = async (scope, deps) => {
     // No sparse fieldsets - return all visible fields
     // This is the default behavior when no ?fields parameter is provided
     Object.entries(schemaStructure).forEach(([field, fieldDef]) => {
+      if (field === 'id' || field === idProperty) return
+
       // Skip virtual fields - they don't exist in database
       if (fieldDef.virtual === true) return
 

--- a/plugins/core/lib/storage/canonical-storage-mapping.js
+++ b/plugins/core/lib/storage/canonical-storage-mapping.js
@@ -116,7 +116,8 @@ export const translateCanonicalRecordFromStorage = (row = {}, descriptor = {}, o
 export const getCanonicalFieldValue = (row, descriptor = {}, fieldName) => {
   if (!row || !fieldName) return undefined
 
-  if (fieldName === 'id') {
+  const idProperty = descriptor.idProperty || 'id'
+  if (fieldName === 'id' || fieldName === idProperty) {
     return getCanonicalResourceId(row, descriptor)
   }
 

--- a/plugins/core/lib/storage/storage-adapter.js
+++ b/plugins/core/lib/storage/storage-adapter.js
@@ -204,10 +204,15 @@ const createCanonicalAdapter = ({ knex, schemaInfo }) => {
   const canonicalFieldMap = descriptor.canonicalFieldMap || {}
   const fieldsInfo = descriptor.fields || {}
   const belongsToInfo = descriptor.belongsTo || {}
+  const idProperty = schemaInfo.idProperty || descriptor.idProperty || 'id'
+  const isLogicalIdField = (field) => field === 'id' || field === idProperty
+  const descriptorWithIdProperty = descriptor.idProperty === idProperty
+    ? descriptor
+    : { ...descriptor, idProperty }
 
   const translateColumn = (field) => {
     if (!field) return field
-    if (field === 'id') return getCanonicalResourceIdColumn(descriptor)
+    if (isLogicalIdField(field)) return getCanonicalResourceIdColumn(descriptor)
 
     const canonicalEntry = canonicalFieldMap[field]
     if (typeof canonicalEntry === 'string') {
@@ -262,7 +267,11 @@ const createCanonicalAdapter = ({ knex, schemaInfo }) => {
   }
 
   const toStorageRow = (attributes) => translateCanonicalAttributesForStorage(attributes, descriptor)
-  const getFieldValue = (record, fieldName) => getCanonicalFieldValue(record, descriptor, fieldName)
+  const getFieldValue = (record, fieldName) => (
+    isLogicalIdField(fieldName)
+      ? getCanonicalFieldValue(record, descriptorWithIdProperty, fieldName)
+      : getCanonicalFieldValue(record, descriptor, fieldName)
+  )
 
   return baseAdapter({
     knex,

--- a/plugins/core/rest-api-anyapi-knex-plugin.js
+++ b/plugins/core/rest-api-anyapi-knex-plugin.js
@@ -122,6 +122,14 @@ export const RestApiAnyapiKnexPlugin = {
       if (!descriptor) {
         throw new Error(`Descriptor not found for resource '${scopeName}'`)
       }
+      const scope = api.resources?.[scopeName] || scopes?.[scopeName]
+      const stored = scopeOptionsRegistry.get(scopeName) || {}
+      descriptor.idProperty = stored.idProperty ||
+        scope?.vars?.schemaInfo?.idProperty ||
+        scope?.scopeOptions?.idProperty ||
+        descriptor.idProperty ||
+        vars.idProperty ||
+        'id'
       return descriptor
     }
 
@@ -1946,6 +1954,7 @@ export const RestApiAnyapiKnexPlugin = {
         scope.vars?.idProperty ||
         vars.idProperty ||
         'id'
+      descriptor.idProperty = idProperty
 
       scope.vars.schemaInfo = {
         ...existingInfo,
@@ -2337,6 +2346,7 @@ export const RestApiAnyapiKnexPlugin = {
         schema,
         relationships,
         canonicalFieldMap: canonicalFieldsMap,
+        idProperty,
       })
 
       const updatedStored = scopeOptionsRegistry.get(scopeName) || {}
@@ -2407,6 +2417,7 @@ export const RestApiAnyapiKnexPlugin = {
         canonicalFieldMap: scopeOptions?.canonicalFieldsMap ||
           scope?.scopeOptions?.canonicalFieldsMap ||
           null,
+        idProperty,
       })
       if (scope) {
         scope.scopeOptions = {

--- a/tests/anyapi-custom-idproperty.test.js
+++ b/tests/anyapi-custom-idproperty.test.js
@@ -1,0 +1,163 @@
+import { describe, it, before, beforeEach, after } from 'node:test'
+import assert from 'node:assert/strict'
+import knexLib from 'knex'
+import { Api } from 'hooked-api'
+
+import { RestApiPlugin, RestApiAnyapiKnexPlugin } from '../index.js'
+import { ensureAnyApiSchema } from '../plugins/core/lib/anyapi/schema-utils.js'
+import { storageMode } from './helpers/storage-mode.js'
+import {
+  createJsonApiDocument,
+  createRelationship,
+  resourceIdentifier,
+} from './helpers/test-utils.js'
+
+const maybeDescribe = storageMode.isAnyApi() ? describe : describe.skip
+
+maybeDescribe('AnyAPI custom idProperty', () => {
+  const knex = knexLib({
+    client: 'better-sqlite3',
+    connection: { filename: ':memory:' },
+    useNullAsDefault: true,
+  })
+
+  let api
+
+  before(async () => {
+    await ensureAnyApiSchema(knex)
+
+    api = new Api({ name: 'anyapi-custom-idproperty-test', log: { level: 'warn' } })
+    await api.use(RestApiPlugin, {
+      simplifiedApi: false,
+      simplifiedTransport: false,
+      returnRecordApi: {
+        post: 'full',
+        put: 'full',
+        patch: 'full',
+      },
+      sortableFields: ['id', 'owner_id', 'item_id', 'code', 'name', 'category'],
+      queryDefaultLimit: 20,
+      queryMaxLimit: 100,
+    })
+    await api.use(RestApiAnyapiKnexPlugin, { knex })
+
+    await api.addResource('owners', {
+      schema: {
+        owner_id: { type: 'id' },
+        name: { type: 'string', required: true },
+      },
+      idProperty: 'owner_id',
+      tableName: 'custom_id_owners',
+    })
+    await api.resources.owners.createKnexTable()
+
+    await api.addResource('items', {
+      schema: {
+        item_id: { type: 'id' },
+        code: { type: 'string', required: true, search: true },
+        name: { type: 'string', required: true },
+        category: { type: 'string', required: true },
+        owner_id: { type: 'id', belongsTo: 'owners', as: 'owner' },
+      },
+      idProperty: 'item_id',
+      tableName: 'custom_id_items',
+    })
+    await api.resources.items.createKnexTable()
+  })
+
+  after(async () => {
+    await api?.release()
+    await knex.destroy()
+  })
+
+  beforeEach(async () => {
+    await knex('any_links').delete()
+    await knex('any_records').delete()
+  })
+
+  it('uses logical ids for post, get, query, sparse fields, cursors, and includes', async () => {
+    const owner = await api.resources.owners.post({
+      inputRecord: createJsonApiDocument('owners', { name: 'Owner One' }),
+      simplified: false,
+    })
+
+    const itemInputs = [
+      { code: 'A001', name: 'Apple', category: 'Fruit' },
+      { code: 'A002', name: 'Apricot', category: 'Fruit' },
+      { code: 'B001', name: 'Broccoli', category: 'Vegetable' },
+      { code: 'C001', name: 'Carrot', category: 'Vegetable' },
+    ]
+
+    const createdItems = []
+    for (const item of itemInputs) {
+      const created = await api.resources.items.post({
+        inputRecord: createJsonApiDocument(
+          'items',
+          item,
+          { owner: createRelationship(resourceIdentifier('owners', owner.data.id)) }
+        ),
+        simplified: false,
+      })
+      createdItems.push(created)
+    }
+
+    const fetched = await api.resources.items.get({
+      id: createdItems[0].data.id,
+      queryParams: {
+        include: ['owner'],
+        fields: {
+          items: 'item_id,code,name,category',
+          owners: 'owner_id,name',
+        },
+      },
+      simplified: false,
+    })
+
+    assert.equal(fetched.data.id, createdItems[0].data.id)
+    assert.equal(fetched.data.attributes.code, 'A001')
+    assert.equal(fetched.data.attributes.name, 'Apple')
+    assert.equal(fetched.data.attributes.item_id, undefined)
+    assert.equal(fetched.included?.[0]?.type, 'owners')
+    assert.equal(fetched.included?.[0]?.id, owner.data.id)
+    assert.equal(fetched.included?.[0]?.attributes.owner_id, undefined)
+
+    const firstPage = await api.resources.items.query({
+      queryParams: {
+        include: ['owner'],
+        fields: {
+          items: 'item_id,code,name,category',
+          owners: 'owner_id,name',
+        },
+        sort: ['category', 'name'],
+        page: { size: 2 },
+      },
+      simplified: false,
+    })
+
+    assert.equal(firstPage.data.length, 2)
+    assert(firstPage.meta.pagination.cursor.next, 'first page should include a next cursor')
+    assert(firstPage.data.every((item) => item.attributes.item_id === undefined))
+    assert(firstPage.included?.some((entry) => entry.type === 'owners' && entry.id === owner.data.id))
+
+    const secondPage = await api.resources.items.query({
+      queryParams: {
+        include: ['owner'],
+        fields: {
+          items: 'item_id,code,name,category',
+          owners: 'owner_id,name',
+        },
+        sort: ['category', 'name'],
+        page: {
+          size: 2,
+          after: firstPage.meta.pagination.cursor.next,
+        },
+      },
+      simplified: false,
+    })
+
+    const firstIds = firstPage.data.map((item) => item.id)
+    const secondIds = secondPage.data.map((item) => item.id)
+    assert.equal(secondPage.data.length, 2)
+    assert(!secondIds.some((id) => firstIds.includes(id)), 'cursor page should not repeat records')
+  })
+})


### PR DESCRIPTION
## Summary
- map custom AnyAPI idProperty fields to canonical logical IDs across descriptors, storage translation, and field selection
- add an AnyAPI custom idProperty regression test covering post, get, query, sparse fields, cursors, and includes
- add the audit fixing checklist with the completed custom-id item checked

## Verification
- npm test
- npm run lint
- JSON_REST_API_STORAGE=anyapi node --test --test-name-pattern "custom id property" tests/pagination-cursor-multifield.test.js
- JSON_REST_API_STORAGE=anyapi node --test tests/anyapi-custom-idproperty.test.js
- JSON_REST_API_STORAGE=anyapi node --test tests/pagination-cursor-multifield.test.js (expected remaining fixture cleanup failures: 5)