### PR TITLE
Fix AnyAPI PUT create parity

### DIFF
--- a/fixing_plan.md
+++ b/fixing_plan.md
@@ -10,11 +10,11 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
   - [x] Ensure cursor, sort, projection, sparse fieldset, and include paths translate both `id` and `idProperty` to `logical_id`.
   - [x] Add AnyAPI tests for custom-id `post`, `get`, `query`, sparse fields, and cursor pagination.
 
-- [ ] Fix AnyAPI PUT create parity.
-  - [ ] Branch `helpers.dataPut` on `context.isCreate`.
-  - [ ] In create mode, insert into `any_records` with tenant, resource, logical id, and translated attributes.
-  - [ ] Keep the current update path for update mode.
-  - [ ] Add legacy Knex and AnyAPI parity tests for `PUT /resource/:id` create, including custom IDs.
+- [x] Fix AnyAPI PUT create parity.
+  - [x] Branch `helpers.dataPut` on `context.isCreate`.
+  - [x] In create mode, insert into `any_records` with tenant, resource, logical id, and translated attributes.
+  - [x] Keep the current update path for update mode.
+  - [x] Add legacy Knex and AnyAPI parity tests for `PUT /resource/:id` create, including custom IDs.
 
 - [ ] Fix pagination link query-string round trips.
   - [ ] Replace manual query-string concatenation with one serializer that is the inverse of `parseJsonApiQuery`.

--- a/plugins/core/rest-api-anyapi-knex-plugin.js
+++ b/plugins/core/rest-api-anyapi-knex-plugin.js
@@ -1040,11 +1040,19 @@ export const RestApiAnyapiKnexPlugin = {
       row[canonical.resourceColumn] = descriptor.resource
       row[canonical.tenantColumn] = descriptor.tenant
 
-      const updateRow = Object.fromEntries(
+      const writeRow = Object.fromEntries(
         Object.entries(row).filter(([, value]) => value !== undefined)
       )
 
-      if (Object.keys(updateRow).length === 0) {
+      if (context.isCreate) {
+        await context.db(canonical.tableName).insert({
+          ...writeRow,
+          [logicalIdColumn]: id,
+        })
+        return 1
+      }
+
+      if (Object.keys(writeRow).length === 0) {
         return 0
       }
 
@@ -1052,7 +1060,7 @@ export const RestApiAnyapiKnexPlugin = {
         .where(logicalIdColumn, id)
         .where(canonical.resourceColumn, descriptor.resource)
         .where(canonical.tenantColumn, descriptor.tenant)
-        .update(updateRow)
+        .update(writeRow)
 
       return result
     }

--- a/tests/put-create-parity.test.js
+++ b/tests/put-create-parity.test.js
@@ -1,0 +1,216 @@
+import { describe, it, before, beforeEach, after } from 'node:test'
+import assert from 'node:assert/strict'
+import knexLib from 'knex'
+import { Api } from 'hooked-api'
+
+import {
+  RestApiAnyapiKnexPlugin,
+  RestApiKnexPlugin,
+  RestApiPlugin,
+} from '../index.js'
+import { ensureAnyApiSchema } from '../plugins/core/lib/anyapi/schema-utils.js'
+import {
+  cleanTables,
+  validateJsonApiStructure,
+} from './helpers/test-utils.js'
+import { storageMode } from './helpers/storage-mode.js'
+
+const knex = knexLib({
+  client: 'better-sqlite3',
+  connection: {
+    filename: ':memory:'
+  },
+  useNullAsDefault: true
+})
+
+const tenantId = 'put_create_parity_tenant'
+const profilesTable = 'put_create_profiles'
+const accountsTable = 'put_create_accounts'
+
+let api
+
+const registerTable = (tableName, resourceName) => {
+  if (storageMode.isAnyApi()) {
+    storageMode.registerTable(tableName, resourceName, tenantId)
+  }
+}
+
+const findStoredRow = async (tableName, resourceName, idColumn, id) => {
+  if (storageMode.isAnyApi()) {
+    return knex('any_records')
+      .where({
+        tenant_id: tenantId,
+        resource: resourceName,
+        logical_id: String(id),
+      })
+      .first()
+  }
+
+  return knex(tableName)
+    .where(idColumn, id)
+    .first()
+}
+
+const countStoredRows = async (tableName, resourceName, idColumn, id) => {
+  if (storageMode.isAnyApi()) {
+    const row = await knex('any_records')
+      .where({
+        tenant_id: tenantId,
+        resource: resourceName,
+        logical_id: String(id),
+      })
+      .count('* as count')
+      .first()
+    return Number(row?.count || 0)
+  }
+
+  const row = await knex(tableName)
+    .where(idColumn, id)
+    .count('* as count')
+    .first()
+  return Number(row?.count || 0)
+}
+
+describe(`PUT create parity (${storageMode.mode})`, () => {
+  before(async () => {
+    if (storageMode.isAnyApi()) {
+      storageMode.clearRegistry()
+      storageMode.setCurrentTenant(tenantId)
+      await ensureAnyApiSchema(knex)
+    }
+
+    api = new Api({
+      name: 'put-create-parity-test',
+      log: { level: 'warn' }
+    })
+
+    await api.use(RestApiPlugin, {
+      simplifiedApi: false,
+      simplifiedTransport: false,
+      returnRecordApi: {
+        post: 'full',
+        put: 'full',
+        patch: 'full'
+      },
+      returnRecordTransport: {
+        post: 'full',
+        put: 'full',
+        patch: 'full'
+      },
+      sortableFields: ['id', 'account_id', 'name', 'code']
+    })
+
+    if (storageMode.isAnyApi()) {
+      await api.use(RestApiAnyapiKnexPlugin, { knex, tenantId })
+    } else {
+      await api.use(RestApiKnexPlugin, { knex })
+    }
+
+    await api.addResource('profiles', {
+      tableName: profilesTable,
+      schema: {
+        id: { type: 'id' },
+        name: { type: 'string', required: true },
+        code: { type: 'string', required: true },
+      }
+    })
+    await api.resources.profiles.createKnexTable()
+    registerTable(profilesTable, 'profiles')
+
+    await api.addResource('accounts', {
+      tableName: accountsTable,
+      idProperty: 'account_id',
+      schema: {
+        name: { type: 'string', required: true },
+        code: { type: 'string', required: true },
+      }
+    })
+    await api.resources.accounts.createKnexTable()
+    registerTable(accountsTable, 'accounts')
+  })
+
+  after(async () => {
+    await api?.release()
+    await knex.destroy()
+    if (storageMode.isAnyApi()) {
+      storageMode.clearRegistry()
+    }
+  })
+
+  beforeEach(async () => {
+    await cleanTables(knex, [profilesTable, accountsTable])
+  })
+
+  it('creates a missing resource through PUT with the default id property', async () => {
+    const created = await api.resources.profiles.put({
+      id: '101',
+      inputRecord: {
+        data: {
+          type: 'profiles',
+          id: '101',
+          attributes: {
+            name: 'Created Profile',
+            code: 'CP'
+          }
+        }
+      },
+      simplified: false
+    })
+
+    validateJsonApiStructure(created)
+    assert.equal(created.data.id, '101')
+    assert.equal(created.data.attributes.name, 'Created Profile')
+
+    const stored = await findStoredRow(profilesTable, 'profiles', 'id', 101)
+    assert(stored, 'PUT create should persist a row')
+  })
+
+  it('creates and then replaces a missing resource through PUT with a custom id property', async () => {
+    const created = await api.resources.accounts.put({
+      id: '501',
+      inputRecord: {
+        data: {
+          type: 'accounts',
+          id: '501',
+          attributes: {
+            name: 'Created Account',
+            code: 'CA'
+          }
+        }
+      },
+      simplified: false
+    })
+
+    validateJsonApiStructure(created)
+    assert.equal(created.data.id, '501')
+    assert.equal(created.data.attributes.name, 'Created Account')
+    assert.equal(created.data.attributes.account_id, undefined)
+
+    const replaced = await api.resources.accounts.put({
+      id: '501',
+      inputRecord: {
+        data: {
+          type: 'accounts',
+          id: '501',
+          attributes: {
+            name: 'Replaced Account',
+            code: 'RA'
+          }
+        }
+      },
+      simplified: false
+    })
+
+    assert.equal(replaced.data.id, '501')
+    assert.equal(replaced.data.attributes.name, 'Replaced Account')
+    assert.equal(await countStoredRows(accountsTable, 'accounts', 'account_id', 501), 1)
+
+    const fetched = await api.resources.accounts.get({
+      id: '501',
+      simplified: false
+    })
+    assert.equal(fetched.data.attributes.name, 'Replaced Account')
+    assert.equal(fetched.data.attributes.code, 'RA')
+    assert.equal(fetched.data.attributes.account_id, undefined)
+  })
+})


### PR DESCRIPTION
## Summary
- make AnyAPI dataPut insert canonical rows when the shared PUT flow marks the operation as create
- preserve the existing scoped update path for existing AnyAPI rows
- add a storage-mode parity test for PUT create and subsequent replace, including custom idProperty resources
- mark the PUT-create checklist item complete

## Verification
- node --test tests/put-create-parity.test.js
- JSON_REST_API_STORAGE=anyapi node --test tests/put-create-parity.test.js
- npm run lint
- npm test