### PR TITLE
Fix pagination link query serialization

### DIFF
--- a/fixing_plan.md
+++ b/fixing_plan.md
@@ -16,11 +16,11 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
   - [x] Keep the current update path for update mode.
   - [x] Add legacy Knex and AnyAPI parity tests for `PUT /resource/:id` create, including custom IDs.
 
-- [ ] Fix pagination link query-string round trips.
-  - [ ] Replace manual query-string concatenation with one serializer that is the inverse of `parseJsonApiQuery`.
-  - [ ] Use `URLSearchParams` for keys and values.
-  - [ ] Map internal `queryParams.filters` back to public JSON:API `filter[...]`.
-  - [ ] Add tests that parse generated `links.next` and prove filters, fields, sort, include, and page params survive round trip.
+- [x] Fix pagination link query-string round trips.
+  - [x] Replace manual query-string concatenation with one serializer that is the inverse of `parseJsonApiQuery`.
+  - [x] Use `URLSearchParams` for keys and values.
+  - [x] Map internal `queryParams.filters` back to public JSON:API `filter[...]`.
+  - [x] Add tests that parse generated `links.next` and prove filters, fields, sort, include, and page params survive round trip.
 
 - [ ] Fix relationship PATCH cardinality validation.
   - [ ] Generate relationship-aware request contracts from relationship metadata.
@@ -108,5 +108,5 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
 - [ ] `npm run verify`
 - [x] Narrow repro for AnyAPI custom `idProperty`
 - [ ] Narrow repro for relationship route `afterCommit`
-- [ ] Narrow repro for pagination link round trip
+- [x] Narrow repro for pagination link round trip
 - [ ] Import smoke test for public exports

--- a/plugins/core/lib/querying-writing/connectors-query-parser.js
+++ b/plugins/core/lib/querying-writing/connectors-query-parser.js
@@ -163,3 +163,54 @@ export function parseJsonApiQuery (queryString) {
 
   return result
 }
+
+const hasSerializableValue = (value) => (
+  value !== undefined &&
+  value !== null &&
+  !(Array.isArray(value) && value.length === 0)
+)
+
+const stringifyQueryValue = (value) => {
+  if (value instanceof Date) return value.toISOString()
+  if (Array.isArray(value)) return value.map(stringifyQueryValue).join(',')
+  return String(value)
+}
+
+const appendCommaList = (params, key, value) => {
+  if (!hasSerializableValue(value)) return
+  const serialized = Array.isArray(value)
+    ? value.map(stringifyQueryValue).filter((entry) => entry.length > 0).join(',')
+    : stringifyQueryValue(value)
+
+  if (serialized) {
+    params.set(key, serialized)
+  }
+}
+
+const appendScopedParams = (params, publicName, values) => {
+  if (!values || typeof values !== 'object' || Array.isArray(values)) return
+
+  for (const [key, value] of Object.entries(values)) {
+    if (!key || !hasSerializableValue(value)) continue
+    params.set(`${publicName}[${key}]`, stringifyQueryValue(value))
+  }
+}
+
+/**
+ * Serializes internal REST API query parameters to public JSON:API query string form.
+ *
+ * This is intentionally the inverse of parseJsonApiQuery for the supported transport
+ * contract: include, sort, filter[...], fields[...], and page[...].
+ */
+export function serializeJsonApiQuery (queryParams = {}, { page } = {}) {
+  const params = new URLSearchParams()
+  const effectivePage = page === undefined ? queryParams.page : page
+
+  appendCommaList(params, 'include', queryParams.include)
+  appendCommaList(params, 'sort', queryParams.sort)
+  appendScopedParams(params, 'filter', queryParams.filters || queryParams.filter)
+  appendScopedParams(params, 'fields', queryParams.fields)
+  appendScopedParams(params, 'page', effectivePage)
+
+  return params.toString()
+}

--- a/plugins/core/lib/querying/knex-pagination-helpers.js
+++ b/plugins/core/lib/querying/knex-pagination-helpers.js
@@ -1,4 +1,10 @@
 import { getFieldValue } from '../storage/storage-mapping.js'
+import { serializeJsonApiQuery } from '../querying-writing/connectors-query-parser.js'
+
+const buildJsonApiLink = (baseUrl, queryParams, page) => {
+  const queryString = serializeJsonApiQuery(queryParams, { page })
+  return queryString ? `${baseUrl}?${queryString}` : baseUrl
+}
 
 /**
  * Calculates pagination metadata from query results
@@ -129,7 +135,7 @@ export const calculatePaginationMeta = (total, page, pageSize) => {
  * Purpose:
  * - JSON:API spec requires pagination links for easy navigation
  * - Preserves all other query parameters (filters, sorts, includes)
- * - Handles complex nested parameters like filter[author][name]=John
+ * - Uses the shared JSON:API query serializer for transport-supported params
  * - Only includes prev/next when applicable
  *
  * Data flow:
@@ -145,52 +151,20 @@ export const generatePaginationLinks = (urlPrefix, scopeName, queryParams, pagin
   const { page, pageCount, pageSize } = paginationMeta
   const links = {}
 
-  const otherParams = Object.entries(queryParams)
-    .filter(([key]) => key !== 'page')
-    .flatMap(([key, value]) => {
-      if (Array.isArray(value)) {
-        return value.length === 0
-          ? []
-          : value.map((v) => `${key}=${encodeURIComponent(v)}`)
-      }
-      if (typeof value === 'object' && value !== null) {
-        const parts = []
-        const processObject = (obj, prefix) => {
-          Object.entries(obj).forEach(([k, v]) => {
-            const newKey = prefix ? `${prefix}[${k}]` : `${key}[${k}]`
-            if (typeof v === 'object' && v !== null && !Array.isArray(v)) {
-              processObject(v, newKey)
-            } else if (v !== undefined && v !== null && !(Array.isArray(v) && v.length === 0)) {
-              parts.push(`${newKey}=${encodeURIComponent(v)}`)
-            }
-          })
-        }
-        processObject(value, key)
-        return parts
-      }
-      if (value === undefined || value === null) {
-        return []
-      }
-      return [`${key}=${encodeURIComponent(value)}`]
-    })
-    .filter(Boolean)
-    .join('&')
-
   const baseUrl = `${urlPrefix}/${scopeName}`
-  const queryPrefix = otherParams ? `?${otherParams}&` : '?'
 
-  links.self = `${baseUrl}${queryPrefix}page[number]=${page}&page[size]=${pageSize}`
+  links.self = buildJsonApiLink(baseUrl, queryParams, { number: page, size: pageSize })
 
   if (pageCount !== undefined) {
-    links.first = `${baseUrl}${queryPrefix}page[number]=1&page[size]=${pageSize}`
-    links.last = `${baseUrl}${queryPrefix}page[number]=${pageCount}&page[size]=${pageSize}`
+    links.first = buildJsonApiLink(baseUrl, queryParams, { number: 1, size: pageSize })
+    links.last = buildJsonApiLink(baseUrl, queryParams, { number: pageCount, size: pageSize })
 
     if (page > 1) {
-      links.prev = `${baseUrl}${queryPrefix}page[number]=${page - 1}&page[size]=${pageSize}`
+      links.prev = buildJsonApiLink(baseUrl, queryParams, { number: page - 1, size: pageSize })
     }
 
     if (page < pageCount) {
-      links.next = `${baseUrl}${queryPrefix}page[number]=${page + 1}&page[size]=${pageSize}`
+      links.next = buildJsonApiLink(baseUrl, queryParams, { number: page + 1, size: pageSize })
     }
   }
 
@@ -446,54 +420,21 @@ export const generateCursorPaginationLinks = (
 
   const links = {}
   const baseUrl = `${urlPrefix}/${scopeName}`
-
-  const otherParams = Object.entries(queryParams)
-    .filter(([key]) => key !== 'page')
-    .flatMap(([key, value]) => {
-      if (Array.isArray(value)) {
-        return value.length === 0
-          ? []
-          : value.map((v) => `${key}=${encodeURIComponent(v)}`)
-      }
-      if (typeof value === 'object' && value !== null) {
-        const parts = []
-        const processObject = (obj, prefix) => {
-          Object.entries(obj).forEach(([k, v]) => {
-            const newKey = prefix ? `${prefix}[${k}]` : `${key}[${k}]`
-            if (typeof v === 'object' && v !== null && !Array.isArray(v)) {
-              processObject(v, newKey)
-            } else if (v !== undefined && v !== null && !(Array.isArray(v) && v.length === 0)) {
-              parts.push(`${newKey}=${encodeURIComponent(v)}`)
-            }
-          })
-        }
-        processObject(value, key)
-        return parts
-      }
-      if (value === undefined || value === null) {
-        return []
-      }
-      return [`${key}=${encodeURIComponent(value)}`]
-    })
-    .filter(Boolean)
-    .join('&')
-
-  const queryPrefix = otherParams ? `?${otherParams}&` : '?'
+  const selfPage = { size: pageSize }
 
   if (queryParams.page?.after) {
-    links.self = `${baseUrl}${queryPrefix}page[size]=${pageSize}&page[after]=${queryParams.page.after}`
+    selfPage.after = queryParams.page.after
   } else if (queryParams.page?.before) {
-    links.self = `${baseUrl}${queryPrefix}page[size]=${pageSize}&page[before]=${queryParams.page.before}`
-  } else {
-    links.self = `${baseUrl}${queryPrefix}page[size]=${pageSize}`
+    selfPage.before = queryParams.page.before
   }
 
-  links.first = `${baseUrl}${queryPrefix}page[size]=${pageSize}`
+  links.self = buildJsonApiLink(baseUrl, queryParams, selfPage)
+  links.first = buildJsonApiLink(baseUrl, queryParams, { size: pageSize })
 
   if (hasMore && records.length > 0) {
     const lastRecord = records[records.length - 1]
     const nextCursor = createCursor(lastRecord, sortFields, { schemaInfo })
-    links.next = `${baseUrl}${queryPrefix}page[size]=${pageSize}&page[after]=${nextCursor}`
+    links.next = buildJsonApiLink(baseUrl, queryParams, { size: pageSize, after: nextCursor })
   }
 
   return links

--- a/tests/anyapi-cursor-pagination.test.js
+++ b/tests/anyapi-cursor-pagination.test.js
@@ -9,10 +9,16 @@ import {
   resourceIdentifier,
 } from './helpers/test-utils.js'
 import { storageMode } from './helpers/storage-mode.js'
+import { parseJsonApiQuery } from '../plugins/core/lib/querying-writing/connectors-query-parser.js'
 
 const isAnyApi = storageMode.isAnyApi()
 
 const maybeDescribe = isAnyApi ? describe : describe.skip
+
+const parseLinkQuery = (link) => {
+  const url = new URL(link, 'https://example.test')
+  return parseJsonApiQuery(url.search.slice(1))
+}
 
 maybeDescribe('AnyAPI Cursor Pagination', () => {
   const knex = knexLib({
@@ -78,7 +84,7 @@ maybeDescribe('AnyAPI Cursor Pagination', () => {
 
     assert.equal(result.data.length, 2)
     assert(result.meta?.pagination?.cursor?.next, 'Should include next cursor')
-    assert(result.links?.next?.includes('page[after]='), 'Next link should include cursor parameter')
+    assert(parseLinkQuery(result.links?.next).page.after, 'Next link should include cursor parameter')
   })
 
   it('paginates forward using page[after]', async () => {

--- a/tests/pagination-enhanced.test.js
+++ b/tests/pagination-enhanced.test.js
@@ -9,6 +9,7 @@ import {
   resourceIdentifier
 } from './helpers/test-utils.js'
 import { createPaginationApi } from './fixtures/api-configs.js'
+import { parseJsonApiQuery } from '../plugins/core/lib/querying-writing/connectors-query-parser.js'
 
 // Create Knex instance for tests
 const knex = knexLib({
@@ -21,6 +22,11 @@ const knex = knexLib({
 
 // API instance that persists across tests
 let api
+
+const parseLinkQuery = (link) => {
+  const url = new URL(link, 'https://example.test')
+  return parseJsonApiQuery(url.search.slice(1))
+}
 
 describe('Enhanced Pagination Features', () => {
   before(async () => {
@@ -207,13 +213,11 @@ describe('Enhanced Pagination Features', () => {
       assert(result.links.prev, 'Should have prev link')
       assert(result.links.next, 'Should have next link')
 
-      // Verify link structure
-      assert(result.links.self.includes('page[number]=2'))
-      assert(result.links.self.includes('page[size]=3'))
-      assert(result.links.first.includes('page[number]=1'))
-      assert(result.links.last.includes('page[number]=4'))
-      assert(result.links.prev.includes('page[number]=1'))
-      assert(result.links.next.includes('page[number]=3'))
+      assert.deepEqual(parseLinkQuery(result.links.self).page, { number: 2, size: 3 })
+      assert.deepEqual(parseLinkQuery(result.links.first).page, { number: 1, size: 3 })
+      assert.deepEqual(parseLinkQuery(result.links.last).page, { number: 4, size: 3 })
+      assert.deepEqual(parseLinkQuery(result.links.prev).page, { number: 1, size: 3 })
+      assert.deepEqual(parseLinkQuery(result.links.next).page, { number: 3, size: 3 })
     })
 
     it('should not include prev link on first page', async () => {
@@ -253,9 +257,9 @@ describe('Enhanced Pagination Features', () => {
 
       assert(result.links, 'Should have links')
       assert(result.links.next, 'Should have next link since page 2 of 4')
-      assert(result.links.next.includes('sort=-title'))
-      assert(result.links.next.includes('page[number]=3'))
-      assert(result.links.next.includes('page[size]=3'))
+      const nextQuery = parseLinkQuery(result.links.next)
+      assert.deepEqual(nextQuery.sort, ['-title'])
+      assert.deepEqual(nextQuery.page, { number: 3, size: 3 })
     })
   })
 
@@ -335,7 +339,7 @@ describe('Enhanced Pagination Features', () => {
       assert(result.links.self)
       assert(result.links.first)
       assert(result.links.next)
-      assert(result.links.next.includes('page[after]='), 'Next link should include cursor parameter')
+      assert(parseLinkQuery(result.links.next).page.after, 'Next link should include cursor parameter')
     })
 
     it('should handle last page with cursor pagination', async () => {
@@ -476,6 +480,10 @@ describe('Enhanced Pagination Features', () => {
           filters: {
             country: parseInt(usCountryId)
           },
+          fields: {
+            books: 'title,country_id',
+            countries: 'name,code'
+          },
           include: ['country'],
           sort: ['title']
         },
@@ -503,10 +511,18 @@ describe('Enhanced Pagination Features', () => {
         assert(book.links.self)
       })
 
-      // Check pagination links include all parameters
-      assert(result.links.next.includes(`filters[country]=${usCountryId}`))
-      assert(result.links.next.includes('include=country'))
-      assert(result.links.next.includes('sort=title'))
+      const nextUrl = new URL(result.links.next, 'https://example.test')
+      const nextQuery = parseJsonApiQuery(nextUrl.search.slice(1))
+      assert.equal(nextUrl.searchParams.get('filter[country]'), usCountryId)
+      assert.equal(nextUrl.searchParams.has('filters[country]'), false)
+      assert.deepEqual(nextQuery.filters, { country: usCountryId })
+      assert.deepEqual(nextQuery.include, ['country'])
+      assert.deepEqual(nextQuery.sort, ['title'])
+      assert.deepEqual(nextQuery.fields, {
+        books: 'title,country_id',
+        countries: 'name,code'
+      })
+      assert.deepEqual(nextQuery.page, { number: 2, size: 5 })
     })
   })
 })


### PR DESCRIPTION
## Summary
- add a serializer beside parseJsonApiQuery for the supported JSON:API transport query contract
- generate offset and cursor pagination links through the serializer instead of manual string concatenation
- emit public filter[...] params from internal queryParams.filters
- update pagination tests to parse generated links and verify filters, fields, sort, include, and page round trips

## Verification
- node --test tests/pagination-enhanced.test.js
- JSON_REST_API_STORAGE=anyapi node --test tests/anyapi-cursor-pagination.test.js
- npm run lint
- npm test