### PR TITLE
Fix relationship cardinality validation

### DIFF
--- a/fixing_plan.md
+++ b/fixing_plan.md
@@ -22,12 +22,12 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
   - [x] Map internal `queryParams.filters` back to public JSON:API `filter[...]`.
   - [x] Add tests that parse generated `links.next` and prove filters, fields, sort, include, and page params survive round trip.
 
-- [ ] Fix relationship PATCH cardinality validation.
-  - [ ] Generate relationship-aware request contracts from relationship metadata.
-  - [ ] Allow to-one relationship PATCH data to be `null` or one resource identifier only.
-  - [ ] Allow to-many relationship data to be arrays only.
-  - [ ] Make `processRelationships()` throw when a belongsTo relationship receives an array.
-  - [ ] Add API and transport tests for invalid to-one arrays and invalid to-many scalars.
+- [x] Fix relationship PATCH cardinality validation.
+  - [x] Generate relationship-aware request contracts from relationship metadata.
+  - [x] Allow to-one relationship PATCH data to be `null` or one resource identifier only.
+  - [x] Allow to-many relationship data to be arrays only.
+  - [x] Make `processRelationships()` throw when a belongsTo relationship receives an array.
+  - [x] Add API and transport tests for invalid to-one arrays and invalid to-many scalars.
 
 - [ ] Run `afterCommit` for relationship routes.
   - [ ] After `postRelationship`, `patchRelationship`, and `deleteRelationship` commit their own transaction, run `afterCommit`.

--- a/plugins/core/lib/querying-writing/relationship-contracts.js
+++ b/plugins/core/lib/querying-writing/relationship-contracts.js
@@ -1,0 +1,56 @@
+import { RestApiValidationError } from '../../../../lib/rest-api-errors.js'
+
+export function getRelationshipCardinality (relDef) {
+  if (!relDef) return null
+
+  if (
+    relDef.belongsTo ||
+    relDef.belongsToPolymorphic ||
+    relDef.type === 'hasOne'
+  ) {
+    return 'one'
+  }
+
+  if (relDef.type === 'hasMany' || relDef.type === 'manyToMany') {
+    return 'many'
+  }
+
+  return null
+}
+
+export function validateRelationshipDataCardinality ({
+  relationshipName,
+  relDef,
+  data,
+  fieldPath = `data.relationships.${relationshipName}.data`
+}) {
+  const cardinality = getRelationshipCardinality(relDef)
+
+  if (cardinality === 'one' && Array.isArray(data)) {
+    throw new RestApiValidationError(
+      `Relationship '${relationshipName}' expects a single resource identifier or null`,
+      {
+        fields: [fieldPath],
+        violations: [{
+          field: fieldPath,
+          rule: 'relationship_cardinality',
+          message: 'Expected a single resource identifier or null'
+        }]
+      }
+    )
+  }
+
+  if (cardinality === 'many' && !Array.isArray(data)) {
+    throw new RestApiValidationError(
+      `Relationship '${relationshipName}' expects an array of resource identifiers`,
+      {
+        fields: [fieldPath],
+        violations: [{
+          field: fieldPath,
+          rule: 'relationship_cardinality',
+          message: 'Expected an array of resource identifiers'
+        }]
+      }
+    )
+  }
+}

--- a/plugins/core/lib/querying-writing/request-contracts.js
+++ b/plugins/core/lib/querying-writing/request-contracts.js
@@ -1,5 +1,6 @@
 import { addType, addValidator, createSchema } from 'json-rest-schema'
 import { RestApiValidationError } from '../../../../lib/rest-api-errors.js'
+import { getRelationshipCardinality } from './relationship-contracts.js'
 
 function isPlainObject (value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
@@ -28,8 +29,19 @@ function buildResourceIdentifierTransportSchema (allowedTypes = null) {
   }
 }
 
-function buildRelationshipDataTransportSchema (allowedTypes = null) {
+function buildRelationshipDataTransportSchema (allowedTypes = null, cardinality = null) {
   const identifierSchema = buildResourceIdentifierTransportSchema(allowedTypes)
+
+  if (cardinality === 'one') {
+    return identifierSchema
+  }
+
+  if (cardinality === 'many') {
+    return {
+      type: 'array',
+      items: identifierSchema
+    }
+  }
 
   return {
     anyOf: [
@@ -156,16 +168,31 @@ function installRequestContractSupport () {
     const allowedTypes = Array.isArray(context.definition.allowedTypes)
       ? context.definition.allowedTypes
       : null
+    const cardinality = context.definition.cardinality || null
 
     if (Array.isArray(context.value)) {
+      if (cardinality === 'one') {
+        context.throwParamError(
+          'INVALID_RELATIONSHIP_CARDINALITY',
+          'Relationship data must be a single resource identifier or null.'
+        )
+      }
       context.value.forEach((entry) => validateResourceIdentifierValue(entry, context, allowedTypes))
       return context.value
+    }
+
+    if (cardinality === 'many') {
+      context.throwParamError(
+        'INVALID_RELATIONSHIP_CARDINALITY',
+        'Relationship data must be an array of resource identifiers.'
+      )
     }
 
     return validateResourceIdentifierValue(context.value, context, allowedTypes)
   }
   jsonApiRelationshipDataType.toJsonSchema = ({ definition }) => buildRelationshipDataTransportSchema(
-    Array.isArray(definition.allowedTypes) ? definition.allowedTypes : null
+    Array.isArray(definition.allowedTypes) ? definition.allowedTypes : null,
+    definition.cardinality || null
   )
   addType('jsonApiRelationshipData', jsonApiRelationshipDataType)
 
@@ -379,6 +406,7 @@ function buildRelationshipStructure (schemaInfo = {}) {
           type: 'jsonApiRelationshipData',
           required: true,
           nullable: true,
+          cardinality: 'one',
           allowedTypes: [fieldDef.belongsTo]
         }
       })
@@ -386,13 +414,15 @@ function buildRelationshipStructure (schemaInfo = {}) {
   }
 
   for (const [relName, relDef] of Object.entries(schemaRelationships)) {
+    const cardinality = getRelationshipCardinality(relDef)
     relationshipStructure[relName] = {
       type: 'object',
       schema: createSchema({
         data: {
           type: 'jsonApiRelationshipData',
           required: true,
-          nullable: true,
+          nullable: cardinality === 'one',
+          cardinality,
           allowedTypes: resolveRelationshipAllowedTypes(relName, relDef)
         }
       })

--- a/plugins/core/lib/writing/relationship-processor.js
+++ b/plugins/core/lib/writing/relationship-processor.js
@@ -1,4 +1,5 @@
 import { RestApiValidationError } from '../../../../lib/rest-api-errors.js'
+import { validateRelationshipDataCardinality } from '../querying-writing/relationship-contracts.js'
 
 /**
  * Processes JSON:API relationship data and converts to database operations
@@ -183,6 +184,14 @@ export const processRelationships = (scope, deps) => {
       fieldDef.as === relName
     )
 
+    if (schemaField || relDef) {
+      validateRelationshipDataCardinality({
+        relationshipName: relName,
+        relDef: schemaField ? schemaField[1] : relDef,
+        data: relData?.data
+      })
+    }
+
     if (schemaField) {
       const [fieldName, fieldDef] = schemaField
 
@@ -235,7 +244,7 @@ export const processRelationships = (scope, deps) => {
           foreignKey: relDef.foreignKey,
           otherKey: relDef.otherKey
         },
-        relData: relData.data || []  // null means empty array for many-to-many
+        relData: relData.data
       })
     }
     // Note: hasOne and hasMany don't need processing here as they don't update the current record

--- a/tests/relationship-endpoints.test.js
+++ b/tests/relationship-endpoints.test.js
@@ -1,5 +1,7 @@
 import { describe, it, before, after, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
+import express from 'express'
+import request from 'supertest'
 import knexLib from 'knex'
 import {
   validateJsonApiStructure,
@@ -23,16 +25,19 @@ const knex = knexLib({
 
 // API instance that persists across tests
 let api
+let app
 
 describe('Relationship Endpoints Plugin', () => {
   before(async () => {
     // Initialize API with the relationships plugin
+    app = express()
     api = await createBasicApi(knex, {
       express: {
         mountPath: ''  // No mount path for this test
       },
       includeExpress: true
     })
+    api.http.express.mount(app)
   })
 
   after(async () => {
@@ -357,5 +362,95 @@ describe('Relationship Endpoints Plugin', () => {
 
     // Note: belongsTo relationships (like 'publisher') are not accessible via relationship endpoints
     // They are foreign key fields, not true JSON:API relationships
+  })
+
+  describe('Relationship Cardinality Validation', () => {
+    let countryId
+    let bookId
+    let authorId
+
+    beforeEach(async () => {
+      await cleanTables(knex, [
+        'basic_countries', 'basic_publishers', 'basic_authors', 'basic_books', 'basic_book_authors'
+      ])
+
+      const country = await api.resources.countries.post({
+        inputRecord: createJsonApiDocument('countries', { name: 'USA', code: 'US' }),
+        simplified: false
+      })
+      countryId = country.data.id
+
+      const book = await api.resources.books.post({
+        inputRecord: createJsonApiDocument(
+          'books',
+          { title: 'Cardinality Book' },
+          { country: createRelationship(resourceIdentifier('countries', countryId)) }
+        ),
+        simplified: false
+      })
+      bookId = book.data.id
+
+      const author = await api.resources.authors.post({
+        inputRecord: createJsonApiDocument('authors', { name: 'Author One' }),
+        simplified: false
+      })
+      authorId = author.data.id
+    })
+
+    it('rejects arrays for to-one relationship PATCH calls', async () => {
+      await assert.rejects(
+        api.resources.books.patchRelationship({
+          id: bookId,
+          relationshipName: 'country',
+          relationshipData: [resourceIdentifier('countries', countryId)]
+        }),
+        (error) => {
+          assert.equal(error.code, 'REST_API_VALIDATION')
+          assert.match(error.message, /single resource identifier or null/)
+          assert(error.details.fields.includes('data.relationships.country.data'))
+          return true
+        }
+      )
+    })
+
+    it('rejects scalars for to-many relationship PATCH calls', async () => {
+      await assert.rejects(
+        api.resources.books.patchRelationship({
+          id: bookId,
+          relationshipName: 'authors',
+          relationshipData: resourceIdentifier('authors', authorId)
+        }),
+        (error) => {
+          assert.equal(error.code, 'REST_API_VALIDATION')
+          assert.match(error.message, /array of resource identifiers/)
+          assert(error.details.fields.includes('data.relationships.authors.data'))
+          return true
+        }
+      )
+    })
+
+    it('rejects invalid relationship cardinality through Express transport', async () => {
+      const toOneResponse = await request(app)
+        .patch(`/books/${bookId}/relationships/country`)
+        .set('Content-Type', 'application/vnd.api+json')
+        .set('Accept', 'application/vnd.api+json')
+        .send({
+          data: [resourceIdentifier('countries', countryId)]
+        })
+
+      assert.equal(toOneResponse.status, 422)
+      assert.match(toOneResponse.body.errors?.[0]?.detail || '', /single resource identifier or null/)
+
+      const toManyResponse = await request(app)
+        .patch(`/books/${bookId}/relationships/authors`)
+        .set('Content-Type', 'application/vnd.api+json')
+        .set('Accept', 'application/vnd.api+json')
+        .send({
+          data: resourceIdentifier('authors', authorId)
+        })
+
+      assert.equal(toManyResponse.status, 422)
+      assert.match(toManyResponse.body.errors?.[0]?.detail || '', /array of resource identifiers/)
+    })
   })
 })


### PR DESCRIPTION
## Summary
- derive relationship cardinality from relationship metadata for JSON:API request contracts
- reject to-one arrays and to-many scalars before relationship writes reach storage helpers
- add direct API and Express transport coverage for invalid relationship PATCH shapes

## Verification
- node --test tests/relationship-endpoints.test.js
- node --test tests/full-jsonapi-belongsto-linkage.test.js tests/relationships.test.js
- JSON_REST_API_STORAGE=anyapi node --test tests/relationship-endpoints.test.js tests/relationships.test.js
- npm run lint
- npm test