### PR TITLE
Run afterCommit for relationship routes

### DIFF
--- a/fixing_plan.md
+++ b/fixing_plan.md
@@ -29,11 +29,11 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
   - [x] Make `processRelationships()` throw when a belongsTo relationship receives an array.
   - [x] Add API and transport tests for invalid to-one arrays and invalid to-many scalars.
 
-- [ ] Run `afterCommit` for relationship routes.
-  - [ ] After `postRelationship`, `patchRelationship`, and `deleteRelationship` commit their own transaction, run `afterCommit`.
-  - [ ] Preserve rollback behavior through `afterRollback`.
-  - [ ] Verify Socket.IO deferred relationship broadcasts work, or define a separate relationship notification policy.
-  - [ ] Add tests with an `afterCommit` hook counter and Socket.IO relationship-write subscription behavior.
+- [x] Run `afterCommit` for relationship routes.
+  - [x] After `postRelationship`, `patchRelationship`, and `deleteRelationship` commit their own transaction, run `afterCommit`.
+  - [x] Preserve rollback behavior through `afterRollback`.
+  - [x] Verify Socket.IO deferred relationship broadcasts work, or define a separate relationship notification policy.
+  - [x] Add tests with an `afterCommit` hook counter and Socket.IO relationship-write subscription behavior.
 
 - [ ] Decide and fix post-commit hook failure semantics. Requires maintainer approval.
   - [ ] Split transaction work from post-commit side effects.
@@ -107,6 +107,6 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
 - [ ] `npm run test:anyapi`
 - [ ] `npm run verify`
 - [x] Narrow repro for AnyAPI custom `idProperty`
-- [ ] Narrow repro for relationship route `afterCommit`
+- [x] Narrow repro for relationship route `afterCommit`
 - [x] Narrow repro for pagination link round trip
 - [ ] Import smoke test for public exports

--- a/plugins/core/rest-api-plugin-methods/delete-relationship.js
+++ b/plugins/core/rest-api-plugin-methods/delete-relationship.js
@@ -117,6 +117,7 @@ export default async function deleteRelationshipMethod ({ params, context, vars,
 
     if (context.shouldCommit) {
       await context.transaction.commit()
+      await runHooks('afterCommit')
     }
 
     // 204 No Content

--- a/plugins/core/rest-api-plugin-methods/patch-relationship.js
+++ b/plugins/core/rest-api-plugin-methods/patch-relationship.js
@@ -53,6 +53,7 @@ export default async function patchRelationshipMethod ({ params, context, vars, 
 
     if (context.shouldCommit) {
       await context.transaction.commit()
+      await runHooks('afterCommit')
     }
 
     // 204 No Content

--- a/plugins/core/rest-api-plugin-methods/post-relationship.js
+++ b/plugins/core/rest-api-plugin-methods/post-relationship.js
@@ -110,6 +110,7 @@ export default async function postRelationshipMethod ({ params, context, vars, h
 
     if (context.shouldCommit) {
       await context.transaction.commit()
+      await runHooks('afterCommit')
     }
 
     // 204 No Content

--- a/tests/relationship-endpoints.test.js
+++ b/tests/relationship-endpoints.test.js
@@ -26,6 +26,8 @@ const knex = knexLib({
 // API instance that persists across tests
 let api
 let app
+const relationshipCommitEvents = []
+const relationshipRollbackEvents = []
 
 describe('Relationship Endpoints Plugin', () => {
   before(async () => {
@@ -38,6 +40,35 @@ describe('Relationship Endpoints Plugin', () => {
       includeExpress: true
     })
     api.http.express.mount(app)
+
+    await api.customize({
+      hooks: {
+        afterCommit: {
+          functionName: 'relationship-after-commit-test-tracker',
+          handler: async ({ context }) => {
+            if (context.method?.endsWith('Relationship')) {
+              relationshipCommitEvents.push({
+                method: context.method,
+                shouldCommit: context.shouldCommit,
+                hasTransaction: !!context.transaction
+              })
+            }
+          }
+        },
+        afterRollback: {
+          functionName: 'relationship-after-rollback-test-tracker',
+          handler: async ({ context }) => {
+            if (context.method?.endsWith('Relationship')) {
+              relationshipRollbackEvents.push({
+                method: context.method,
+                shouldCommit: context.shouldCommit,
+                hasTransaction: !!context.transaction
+              })
+            }
+          }
+        }
+      }
+    })
   })
 
   after(async () => {
@@ -451,6 +482,100 @@ describe('Relationship Endpoints Plugin', () => {
 
       assert.equal(toManyResponse.status, 422)
       assert.match(toManyResponse.body.errors?.[0]?.detail || '', /array of resource identifiers/)
+    })
+  })
+
+  describe('Relationship Transaction Hooks', () => {
+    let countryId
+    let secondCountryId
+    let bookId
+    let authorId
+
+    beforeEach(async () => {
+      relationshipCommitEvents.length = 0
+      relationshipRollbackEvents.length = 0
+
+      await cleanTables(knex, [
+        'basic_countries', 'basic_publishers', 'basic_authors', 'basic_books', 'basic_book_authors'
+      ])
+
+      const country = await api.resources.countries.post({
+        inputRecord: createJsonApiDocument('countries', { name: 'USA', code: 'US' }),
+        simplified: false
+      })
+      countryId = country.data.id
+
+      const secondCountry = await api.resources.countries.post({
+        inputRecord: createJsonApiDocument('countries', { name: 'Canada', code: 'CA' }),
+        simplified: false
+      })
+      secondCountryId = secondCountry.data.id
+
+      const book = await api.resources.books.post({
+        inputRecord: createJsonApiDocument(
+          'books',
+          { title: 'Hook Book' },
+          { country: createRelationship(resourceIdentifier('countries', countryId)) }
+        ),
+        simplified: false
+      })
+      bookId = book.data.id
+
+      const author = await api.resources.authors.post({
+        inputRecord: createJsonApiDocument('authors', { name: 'Hook Author' }),
+        simplified: false
+      })
+      authorId = author.data.id
+
+      relationshipCommitEvents.length = 0
+      relationshipRollbackEvents.length = 0
+    })
+
+    it('runs afterCommit for relationship methods that own their transaction', async () => {
+      await api.resources.books.postRelationship({
+        id: bookId,
+        relationshipName: 'authors',
+        relationshipData: [resourceIdentifier('authors', authorId)]
+      })
+
+      await api.resources.books.patchRelationship({
+        id: bookId,
+        relationshipName: 'country',
+        relationshipData: resourceIdentifier('countries', secondCountryId)
+      })
+
+      await api.resources.books.deleteRelationship({
+        id: bookId,
+        relationshipName: 'authors',
+        relationshipData: [resourceIdentifier('authors', authorId)]
+      })
+
+      assert.deepEqual(
+        relationshipCommitEvents.map((event) => event.method),
+        ['postRelationship', 'patchRelationship', 'deleteRelationship']
+      )
+      assert(relationshipCommitEvents.every((event) => event.shouldCommit))
+      assert(relationshipCommitEvents.every((event) => event.hasTransaction))
+      assert.equal(relationshipRollbackEvents.length, 0)
+    })
+
+    it('preserves afterRollback for failed relationship methods that own their transaction', async () => {
+      await assert.rejects(
+        api.resources.books.postRelationship({
+          id: bookId,
+          relationshipName: 'missing',
+          relationshipData: []
+        }),
+        /Relationship 'missing' not found/
+      )
+
+      assert.deepEqual(
+        relationshipRollbackEvents.map((event) => event.method),
+        ['postRelationship']
+      )
+      assert(relationshipRollbackEvents[0].shouldCommit)
+      assert(relationshipRollbackEvents[0].hasTransaction)
+      assert.equal(relationshipCommitEvents.length, 0)
     })
   })
 })

--- a/tests/socketio.test.js
+++ b/tests/socketio.test.js
@@ -453,6 +453,68 @@ describe('WebSocket/Socket.IO Plugin', () => {
         socket.close()
       }
     })
+
+    it('should broadcast deferred patch notifications from relationship PATCH', async () => {
+      const token = await createToken({ userId: 'test-user', role: 'user' }, 'test-secret-key')
+
+      const socket = ioClient(`http://localhost:${server.address().port}`, {
+        path: '/api/socket.io',
+        auth: { token }
+      })
+
+      try {
+        await new Promise((resolve, reject) => {
+          socket.on('connect', resolve)
+          socket.on('connect_error', reject)
+          setTimeout(() => reject(new Error('Connection timeout')), 5000)
+        })
+
+        const country = await api.resources.countries.post({
+          inputRecord: createJsonApiDocument('countries', {
+            name: 'Original Country',
+            code: 'OC'
+          }),
+          simplified: false
+        })
+
+        const nextCountry = await api.resources.countries.post({
+          inputRecord: createJsonApiDocument('countries', {
+            name: 'Next Country',
+            code: 'NC'
+          }),
+          simplified: false
+        })
+
+        const book = await api.resources.books.post({
+          inputRecord: createJsonApiDocument(
+            'books',
+            { title: 'Relationship Patch Broadcast' },
+            { country: createRelationship(resourceIdentifier('countries', country.data.id)) }
+          ),
+          simplified: false
+        })
+
+        await new Promise((resolve) => {
+          socket.emit('subscribe', { resource: 'books' }, resolve)
+        })
+
+        const updatePromise = waitForSocketEvent(socket, 'subscription.update', 1000)
+
+        await api.resources.books.patchRelationship({
+          id: book.data.id,
+          relationshipName: 'country',
+          relationshipData: resourceIdentifier('countries', nextCountry.data.id)
+        })
+
+        const notification = await updatePromise
+        assert.equal(notification.type, 'resource.patchd')
+        assert.equal(notification.resource, 'books')
+        assert.equal(String(notification.id), String(book.data.id))
+        assert.equal(notification.action, 'patch')
+      } finally {
+        socket.close()
+      }
+    })
   })
 
   describe('Multiple Subscriptions', () => {


### PR DESCRIPTION
## Summary
- run afterCommit after postRelationship, patchRelationship, and deleteRelationship commit their own transactions
- add hook-counter coverage for relationship afterCommit and afterRollback behavior
- verify Socket.IO deferred patch broadcasts are released after relationship PATCH commits

## Verification
- node --test --test-name-pattern "runs afterCommit for relationship methods|preserves afterRollback" tests/relationship-endpoints.test.js
- node --test --test-name-pattern "relationship PATCH" tests/socketio.test.js
- node --test tests/relationship-endpoints.test.js
- node --test tests/socketio.test.js
- JSON_REST_API_STORAGE=anyapi node --test tests/relationship-endpoints.test.js
- JSON_REST_API_STORAGE=anyapi node --test --test-name-pattern "relationship PATCH" tests/socketio.test.js
- npm run lint
- npm test

## Known remaining failure
- npm run test:anyapi still fails in tests/pagination-cursor-multifield.test.js with 5 cursor/cleanup failures; this is the next planned checklist item, and the relationship-specific AnyAPI checks above pass.