### PR TITLE
Fix AnyAPI pagination fixture cleanup

### DIFF
--- a/fixing_plan.md
+++ b/fixing_plan.md
@@ -43,10 +43,10 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
 
 ## Medium Priority
 
-- [ ] Fix AnyAPI pagination fixture cleanup.
-  - [ ] Register `cursor_products` and `cursor_items` with `storageMode.registerTable()` in `createCursorPaginationApi`.
-  - [ ] Add a focused cleanup test proving `cleanTables(knex, ['cursor_products'])` deletes matching `any_records`.
-  - [ ] Consider deriving AnyAPI cleanup mappings from API metadata later if a broader helper refactor is approved.
+- [x] Fix AnyAPI pagination fixture cleanup.
+  - [x] Register `cursor_products` and `cursor_items` with `storageMode.registerTable()` in `createCursorPaginationApi`.
+  - [x] Add a focused cleanup test proving `cleanTables(knex, ['cursor_products'])` deletes matching `any_records`.
+  - [x] Keep metadata-derived cleanup mappings as a later refactor if a broader helper change is approved.
 
 - [ ] Fix file temp and orphan cleanup.
   - [ ] Wrap file processing in `try/finally` so detector temp files are cleaned after validation failures.
@@ -102,9 +102,9 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
 
 ## Verification Checklist
 
-- [ ] `npm test`
-- [ ] `npm run lint`
-- [ ] `npm run test:anyapi`
+- [x] `npm test`
+- [x] `npm run lint`
+- [x] `npm run test:anyapi`
 - [ ] `npm run verify`
 - [x] Narrow repro for AnyAPI custom `idProperty`
 - [x] Narrow repro for relationship route `afterCommit`

--- a/tests/fixtures/api-configs.js
+++ b/tests/fixtures/api-configs.js
@@ -1925,6 +1925,7 @@ export async function createCursorPaginationApi (knex) {
     tableName: 'cursor_products'
   })
   await api.resources.products.createKnexTable()
+  mapTable('cursor_products', 'products')
 
   // Create items table with custom ID property
   await api.addResource('items', {
@@ -1939,6 +1940,7 @@ export async function createCursorPaginationApi (knex) {
     tableName: 'cursor_items'
   })
   await api.resources.items.createKnexTable()
+  mapTable('cursor_items', 'items')
 
   return api
 }

--- a/tests/pagination-cursor-multifield.test.js
+++ b/tests/pagination-cursor-multifield.test.js
@@ -7,6 +7,7 @@ import {
   createJsonApiDocument
 } from './helpers/test-utils.js'
 import { createCursorPaginationApi } from './fixtures/api-configs.js'
+import { storageMode } from './helpers/storage-mode.js'
 
 // Create Knex instance for tests
 const knex = knexLib({
@@ -19,6 +20,19 @@ const knex = knexLib({
 
 // API instance that persists across tests
 let api
+const anyapiIt = storageMode.isAnyApi() ? it : it.skip
+
+async function countAnyRecords (resource) {
+  const result = await knex('any_records')
+    .where({
+      tenant_id: api.anyapi.tenantId,
+      resource
+    })
+    .count('* as count')
+    .first()
+
+  return Number(result?.count ?? 0)
+}
 
 describe('Multi-field Cursor Pagination', () => {
   before(async () => {
@@ -29,6 +43,43 @@ describe('Multi-field Cursor Pagination', () => {
   after(async () => {
     // Close database connection
     await knex.destroy()
+  })
+
+  anyapiIt('cleans cursor fixture records from AnyAPI canonical storage', async () => {
+    await cleanTables(knex, ['cursor_products', 'cursor_items'])
+
+    await api.resources.products.post({
+      inputRecord: createJsonApiDocument('products', {
+        name: 'Cleanup Product',
+        category: 'Cleanup',
+        brand: 'Fixture',
+        price: 10,
+        sku: 'CLEAN-001'
+      }),
+      simplified: false
+    })
+
+    await api.resources.items.post({
+      inputRecord: createJsonApiDocument('items', {
+        code: 'CLEAN',
+        name: 'Cleanup Item',
+        category: 'Cleanup',
+        type: 'fixture'
+      }),
+      simplified: false
+    })
+
+    assert.equal(await countAnyRecords('products'), 1)
+    assert.equal(await countAnyRecords('items'), 1)
+
+    await cleanTables(knex, ['cursor_products'])
+
+    assert.equal(await countAnyRecords('products'), 0)
+    assert.equal(await countAnyRecords('items'), 1)
+
+    await cleanTables(knex, ['cursor_items'])
+
+    assert.equal(await countAnyRecords('items'), 0)
   })
 
   describe('Basic Multi-field Cursor Pagination', () => {


### PR DESCRIPTION
## Summary
- register cursor pagination fixture tables with storageMode so AnyAPI cleanTables removes canonical records
- add an AnyAPI-only cleanup regression covering cursor_products and cursor_items canonical any_records rows
- update the fixing plan with passing npm test, lint, and full AnyAPI verification

## Verification
- JSON_REST_API_STORAGE=anyapi node --test tests/pagination-cursor-multifield.test.js
- node --test tests/pagination-cursor-multifield.test.js
- npm run lint
- npm run test:anyapi
- npm test