### PR TITLE
Fix file upload cleanup

### DIFF
--- a/docs/GUIDE/GUIDE_X_File_Uploads.md
+++ b/docs/GUIDE/GUIDE_X_File_Uploads.md
@@ -218,11 +218,14 @@ class MyCustomStorage {
   }
   
   async delete(url) {
-    // Optional: implement file deletion
+    // Optional but recommended: FileHandlingPlugin calls this after
+    // an uploaded file's write transaction rolls back.
     await deleteFileSomewhere(url);
   }
 }
 ```
+
+`FileHandlingPlugin` always calls detector-provided `file.cleanup()` after parsing, including validation failures. If a file has already been uploaded and the later resource write rolls back, the plugin calls `storage.delete(url)` when the adapter implements it. Storage adapters that need rollback cleanup should make `delete(url)` idempotent for URLs returned by `upload(file)`.
 
 ## Protocol Configuration
 

--- a/fixing_plan.md
+++ b/fixing_plan.md
@@ -48,12 +48,12 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
   - [x] Add a focused cleanup test proving `cleanTables(knex, ['cursor_products'])` deletes matching `any_records`.
   - [x] Keep metadata-derived cleanup mappings as a later refactor if a broader helper change is approved.
 
-- [ ] Fix file temp and orphan cleanup.
-  - [ ] Wrap file processing in `try/finally` so detector temp files are cleaned after validation failures.
-  - [ ] Track successfully uploaded URLs on `context`.
-  - [ ] On rollback or later write error, call storage `delete(url)` where available.
-  - [ ] Document `delete(url)` as the rollback-capable storage contract.
-  - [ ] Add tests for invalid MIME cleanup and post-upload DB/validation rollback cleanup.
+- [x] Fix file temp and orphan cleanup.
+  - [x] Wrap file processing in `try/finally` so detector temp files are cleaned after validation failures.
+  - [x] Track successfully uploaded URLs on `context`.
+  - [x] On rollback or later write error, call storage `delete(url)` where available.
+  - [x] Document `delete(url)` as the rollback-capable storage contract.
+  - [x] Add tests for invalid MIME cleanup and post-upload DB/validation rollback cleanup.
 
 - [ ] Harden `LocalStorage` path containment.
   - [ ] Sanitize or reject custom basenames containing `/`, `\`, drive prefixes, or empty names.
@@ -105,7 +105,7 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
 - [x] `npm test`
 - [x] `npm run lint`
 - [x] `npm run test:anyapi`
-- [ ] `npm run verify`
+- [x] `npm run verify`
 - [x] Narrow repro for AnyAPI custom `idProperty`
 - [x] Narrow repro for relationship route `afterCommit`
 - [x] Narrow repro for pagination link round trip

--- a/plugins/core/file-handling-plugin.js
+++ b/plugins/core/file-handling-plugin.js
@@ -65,6 +65,43 @@ export const FileHandlingPlugin = {
     // Store detectors array for inspection
     api.rest.fileDetectors = detectorRegistry
 
+    const trackUploadedFile = (context, upload) => {
+      if (!context.fileHandlingUploads) {
+        context.fileHandlingUploads = []
+      }
+      context.fileHandlingUploads.push(upload)
+    }
+
+    const cleanupParsedFiles = async (files = {}) => {
+      for (const file of Object.values(files)) {
+        if (!file?.cleanup) continue
+
+        try {
+          await file.cleanup()
+        } catch (error) {
+          log.warn('Failed to cleanup temp file:', error)
+        }
+      }
+    }
+
+    const cleanupUploadedFiles = async (context) => {
+      const uploads = context.fileHandlingUploads
+      if (!uploads || uploads.length === 0) return
+
+      context.fileHandlingUploads = []
+      for (const upload of uploads) {
+        if (!upload?.url || typeof upload.storage?.delete !== 'function') {
+          continue
+        }
+
+        try {
+          await upload.storage.delete(upload.url)
+        } catch (error) {
+          log.warn(`Failed to cleanup uploaded file '${upload.url}' after rollback:`, error)
+        }
+      }
+    }
+
     /**
      * Analyze a scope's schema to find file fields
      */
@@ -152,125 +189,114 @@ export const FileHandlingPlugin = {
       }
 
       log.debug(`Processing files with detector '${detectorUsed}'`)
-      const { fields, files } = parsed
+      const { fields = {}, files = {} } = parsed
 
-      // Process each file field defined in schema
-      for (const fieldConfig of fileFields) {
-        const file = files[fieldConfig.field]
+      try {
+        // Process each file field defined in schema
+        for (const fieldConfig of fileFields) {
+          const file = files[fieldConfig.field]
 
-        if (!file) {
-          if (fieldConfig.required) {
-            throw new RestApiValidationError(
-              `Required file field '${fieldConfig.field}' is missing`,
-              {
-                fields: [fieldConfig.field],
-                violations: [{
-                  field: fieldConfig.field,
-                  message: 'This field is required'
-                }]
-              }
-            )
-          }
-          continue
-        }
-
-        // Validate mime type
-        if (fieldConfig.accepts[0] !== '*') {
-          const acceptable = fieldConfig.accepts.some(pattern => {
-            if (pattern.endsWith('/*')) {
-              // e.g., 'image/*'
-              const prefix = pattern.slice(0, -2)
-              return file.mimetype.startsWith(prefix + '/')
+          if (!file) {
+            if (fieldConfig.required) {
+              throw new RestApiValidationError(
+                `Required file field '${fieldConfig.field}' is missing`,
+                {
+                  fields: [fieldConfig.field],
+                  violations: [{
+                    field: fieldConfig.field,
+                    message: 'This field is required'
+                  }]
+                }
+              )
             }
-            return file.mimetype === pattern
-          })
-
-          if (!acceptable) {
-            throw new RestApiValidationError(
-              `Invalid file type for field '${fieldConfig.field}'`,
-              {
-                fields: [fieldConfig.field],
-                violations: [{
-                  field: fieldConfig.field,
-                  message: `Expected ${fieldConfig.accepts.join(' or ')}, got ${file.mimetype}`
-                }]
-              }
-            )
+            continue
           }
-        }
 
-        // Validate file size
-        if (fieldConfig.maxSize) {
-          const maxBytes = parseSize(fieldConfig.maxSize)
-          if (file.size > maxBytes) {
-            throw new RestApiValidationError(
-              `File too large for field '${fieldConfig.field}'`,
-              {
-                fields: [fieldConfig.field],
-                violations: [{
-                  field: fieldConfig.field,
-                  message: `Maximum size is ${fieldConfig.maxSize}, got ${formatSize(file.size)}`
-                }]
+          // Validate mime type
+          if (fieldConfig.accepts[0] !== '*') {
+            const acceptable = fieldConfig.accepts.some(pattern => {
+              if (pattern.endsWith('/*')) {
+                // e.g., 'image/*'
+                const prefix = pattern.slice(0, -2)
+                return file.mimetype.startsWith(prefix + '/')
               }
-            )
-          }
-        }
+              return file.mimetype === pattern
+            })
 
-        // Upload to storage
-        if (!fieldConfig.storage) {
-          throw new Error(`No storage configured for file field '${fieldConfig.field}'`)
-        }
-
-        try {
-          const storedUrl = await fieldConfig.storage.upload(file)
-          fields[fieldConfig.field] = storedUrl
-          log.debug(`Uploaded file for field '${fieldConfig.field}' to: ${storedUrl}`)
-        } catch (error) {
-          // Cleanup if file has cleanup function
-          if (file.cleanup) {
-            try {
-              await file.cleanup()
-            } catch (cleanupError) {
-              log.warn('Failed to cleanup file after upload error:', cleanupError)
+            if (!acceptable) {
+              throw new RestApiValidationError(
+                `Invalid file type for field '${fieldConfig.field}'`,
+                {
+                  fields: [fieldConfig.field],
+                  violations: [{
+                    field: fieldConfig.field,
+                    message: `Expected ${fieldConfig.accepts.join(' or ')}, got ${file.mimetype}`
+                  }]
+                }
+              )
             }
           }
 
-          throw new RestApiValidationError(
-            `Failed to upload file for field '${fieldConfig.field}': ${error.message}`,
-            {
-              fields: [fieldConfig.field],
-              violations: [{
-                field: fieldConfig.field,
-                message: error.message
-              }]
+          // Validate file size
+          if (fieldConfig.maxSize) {
+            const maxBytes = parseSize(fieldConfig.maxSize)
+            if (file.size > maxBytes) {
+              throw new RestApiValidationError(
+                `File too large for field '${fieldConfig.field}'`,
+                {
+                  fields: [fieldConfig.field],
+                  violations: [{
+                    field: fieldConfig.field,
+                    message: `Maximum size is ${fieldConfig.maxSize}, got ${formatSize(file.size)}`
+                  }]
+                }
+              )
             }
-          )
-        }
-      }
+          }
 
-      // Replace inputRecord with processed data
-      if (!params.inputRecord) {
-        params.inputRecord = { data: { attributes: {} } }
-      }
-      if (!params.inputRecord.data) {
-        params.inputRecord.data = { attributes: {} }
-      }
-      if (!params.inputRecord.data.attributes) {
-        params.inputRecord.data.attributes = {}
-      }
+          // Upload to storage
+          if (!fieldConfig.storage) {
+            throw new Error(`No storage configured for file field '${fieldConfig.field}'`)
+          }
 
-      // Merge fields into attributes
-      Object.assign(params.inputRecord.data.attributes, fields)
-
-      // Cleanup any remaining temp files
-      for (const file of Object.values(files)) {
-        if (file.cleanup) {
           try {
-            await file.cleanup()
+            const storedUrl = await fieldConfig.storage.upload(file)
+            fields[fieldConfig.field] = storedUrl
+            trackUploadedFile(context, {
+              field: fieldConfig.field,
+              storage: fieldConfig.storage,
+              url: storedUrl
+            })
+            log.debug(`Uploaded file for field '${fieldConfig.field}' to: ${storedUrl}`)
           } catch (error) {
-            log.warn('Failed to cleanup temp file:', error)
+            throw new RestApiValidationError(
+              `Failed to upload file for field '${fieldConfig.field}': ${error.message}`,
+              {
+                fields: [fieldConfig.field],
+                violations: [{
+                  field: fieldConfig.field,
+                  message: error.message
+                }]
+              }
+            )
           }
         }
+
+        // Replace inputRecord with processed data
+        if (!params.inputRecord) {
+          params.inputRecord = { data: { attributes: {} } }
+        }
+        if (!params.inputRecord.data) {
+          params.inputRecord.data = { attributes: {} }
+        }
+        if (!params.inputRecord.data.attributes) {
+          params.inputRecord.data.attributes = {}
+        }
+
+        // Merge fields into attributes
+        Object.assign(params.inputRecord.data.attributes, fields)
+      } finally {
+        await cleanupParsedFiles(files)
       }
     }
 
@@ -289,6 +315,10 @@ export const FileHandlingPlugin = {
 
       // Process files if this scope has file fields
       await processFiles(scopeName, params, context)
+    })
+
+    addHook('afterRollback', 'cleanupUploadedFiles', {}, async ({ context }) => {
+      await cleanupUploadedFiles(context)
     })
 
     log.info('File handling plugin initialized successfully')

--- a/plugins/core/lib/anyapi/schema-utils.js
+++ b/plugins/core/lib/anyapi/schema-utils.js
@@ -210,6 +210,7 @@ export const TYPE_TO_POOL = new Map([
   ['text', 'string'],
   ['uuid', 'string'],
   ['email', 'string'],
+  ['file', 'string'],
   ['number', 'number'],
   ['integer', 'number'],
   ['float', 'number'],

--- a/tests/file-handling.test.js
+++ b/tests/file-handling.test.js
@@ -1,0 +1,118 @@
+import { describe, it, before, after, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import knexLib from 'knex'
+import { cleanTables } from './helpers/test-utils.js'
+import { createFileUploadApi } from './fixtures/api-configs.js'
+
+const knex = knexLib({
+  client: 'better-sqlite3',
+  connection: {
+    filename: ':memory:'
+  },
+  useNullAsDefault: true
+})
+
+let api
+let detectorState
+let storage
+
+function createTrackingStorage () {
+  return {
+    uploaded: [],
+    deleted: [],
+
+    async upload (file) {
+      const url = `/uploads/${file.filename}`
+      this.uploaded.push(url)
+      return url
+    },
+
+    async delete (url) {
+      this.deleted.push(url)
+    }
+  }
+}
+
+function createTestFile ({ filename = 'upload.png', mimetype = 'image/png', cleanup } = {}) {
+  return {
+    filename,
+    mimetype,
+    size: 1,
+    data: Buffer.from('x'),
+    cleanup
+  }
+}
+
+describe('File handling cleanup', () => {
+  before(async () => {
+    detectorState = { payload: null }
+    storage = createTrackingStorage()
+    api = await createFileUploadApi(knex, { detectorState, storage })
+  })
+
+  after(async () => {
+    await knex.destroy()
+  })
+
+  beforeEach(async () => {
+    await cleanTables(knex, ['file_documents'])
+    detectorState.payload = null
+    storage.uploaded = []
+    storage.deleted = []
+  })
+
+  it('cleans detector temp files when MIME validation rejects an upload', async () => {
+    let cleanupCalls = 0
+    detectorState.payload = {
+      fields: { title: 'Invalid MIME' },
+      files: {
+        attachment: createTestFile({
+          filename: 'invalid.txt',
+          mimetype: 'text/plain',
+          cleanup: async () => {
+            cleanupCalls++
+          }
+        })
+      }
+    }
+
+    await assert.rejects(
+      api.resources.documents.post({
+        inputRecord: { data: { type: 'documents', attributes: {} } },
+        simplified: false
+      }),
+      /Invalid file type for field 'attachment'/
+    )
+
+    assert.equal(cleanupCalls, 1)
+    assert.deepEqual(storage.uploaded, [])
+    assert.deepEqual(storage.deleted, [])
+  })
+
+  it('deletes uploaded files when a later write validation error rolls back', async () => {
+    let cleanupCalls = 0
+    detectorState.payload = {
+      fields: {},
+      files: {
+        attachment: createTestFile({
+          filename: 'valid.png',
+          cleanup: async () => {
+            cleanupCalls++
+          }
+        })
+      }
+    }
+
+    await assert.rejects(
+      api.resources.documents.post({
+        inputRecord: { data: { type: 'documents', attributes: {} } },
+        simplified: false
+      }),
+      /Schema validation failed for resource attributes/
+    )
+
+    assert.equal(cleanupCalls, 1)
+    assert.deepEqual(storage.uploaded, ['/uploads/valid.png'])
+    assert.deepEqual(storage.deleted, ['/uploads/valid.png'])
+  })
+})

--- a/tests/fixtures/api-configs.js
+++ b/tests/fixtures/api-configs.js
@@ -1,5 +1,5 @@
 import { Api } from 'hooked-api'
-import { RestApiPlugin, RestApiKnexPlugin, RestApiAnyapiKnexPlugin, QueryProjectionsPlugin } from '../../index.js'
+import { RestApiPlugin, RestApiKnexPlugin, RestApiAnyapiKnexPlugin, QueryProjectionsPlugin, FileHandlingPlugin } from '../../index.js'
 import { ExpressPlugin } from '../../plugins/core/connectors/express-plugin.js'
 import express from 'express'
 import { createServer } from 'http'
@@ -2102,4 +2102,84 @@ export async function createSearchSchemaMergeApi (knex, pluginOptions = {}) {
   mapTable('searchmerge_orders', 'orders')
 
   return api
+}
+
+export async function createFileUploadApi (knex, pluginOptions = {}) {
+  const apiName = pluginOptions.apiName || 'file-upload-test-api'
+  const tableName = pluginOptions.tableName || 'file_documents'
+  const tablePrefix = pluginOptions.tablePrefix || 'file'
+  const storage = pluginOptions.storage
+  const detectorState = pluginOptions.detectorState || { payload: null }
+
+  if (!storage) {
+    throw new Error('createFileUploadApi requires a storage adapter')
+  }
+
+  if (storageMode.isAnyApi()) {
+    storageMode.clearRegistry()
+  }
+
+  const api = new Api({
+    name: apiName,
+    log: { level: process.env.LOG_LEVEL || 'info' }
+  })
+
+  const previousTenant = storageMode.currentTenant
+  const tenantId = storageMode.isAnyApi()
+    ? (pluginOptions.tenantId || `${tablePrefix}_tenant`)
+    : storageMode.defaultTenant
+
+  if (storageMode.isAnyApi()) {
+    storageMode.setCurrentTenant(tenantId)
+  }
+
+  try {
+    await api.use(RestApiPlugin, {
+      simplifiedApi: false,
+      simplifiedTransport: false,
+      returnRecordApi: {
+        post: true,
+        put: false,
+        patch: false
+      },
+      returnRecordTransport: {
+        post: 'full',
+        put: 'no',
+        patch: 'minimal'
+      },
+      sortableFields: ['id', 'title'],
+      ...pluginOptions['rest-api']
+    })
+    await useStoragePlugin(api, knex, { tenantId })
+    await resetAnyApiTables(knex)
+    await api.use(FileHandlingPlugin)
+
+    api.rest.registerFileDetector({
+      name: 'test-file-detector',
+      detect: () => Boolean(detectorState.payload),
+      parse: async () => detectorState.payload
+    })
+
+    await api.addResource('documents', {
+      schema: {
+        id: { type: 'id' },
+        title: { type: 'string', required: true },
+        attachment: {
+          type: 'file',
+          storage,
+          accepts: ['image/png'],
+          maxSize: '1mb'
+        }
+      },
+      tableName
+    })
+    await api.resources.documents.createKnexTable()
+    mapTable(tableName, 'documents')
+
+    return api
+  } finally {
+    if (storageMode.isAnyApi()) {
+      storageMode.setCurrentTenant(previousTenant)
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- clean detector temp files from file processing via try/finally
- track successful file uploads on request context and delete them on rollback when storage supports delete(url)
- allow AnyAPI file fields to use string canonical slots, matching uploaded URL storage
- document rollback cleanup contract and add file cleanup tests

## Verification
- node --test tests/file-handling.test.js
- JSON_REST_API_STORAGE=anyapi node --test tests/file-handling.test.js
- npm run lint
- npm test
- npm run test:anyapi
- npm run verify