### PR TITLE
Harden LocalStorage path containment

### DIFF
--- a/docs/GUIDE/GUIDE_X_File_Uploads.md
+++ b/docs/GUIDE/GUIDE_X_File_Uploads.md
@@ -187,9 +187,11 @@ const localStorage = new LocalStorage({
    }
    // Result: "user_12345_1672531200000.jpg"
    ```
+   Custom generators must return a basename only, not a path. Values containing `/`, `\`, drive prefixes, or only whitespace are rejected.
 
 **Security Features:**
-- Path traversal protection (removes `..` and `/`)
+- Path traversal protection (sanitizes original names and rejects path-like custom names)
+- Custom generated names are restricted to basenames
 - Control character filtering
 - Extension validation against whitelist
 - Automatic duplicate handling
@@ -539,11 +541,11 @@ const organizedStorage = new LocalStorage({
   nameStrategy: 'custom',
   nameGenerator: async (file) => {
     const date = new Date();
-    const dateDir = `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}`;
-    return `${dateDir}/${crypto.randomBytes(16).toString('hex')}`;
+    const datePrefix = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+    return `${datePrefix}-${crypto.randomBytes(16).toString('hex')}`;
   }
 });
-// Saves as: "2024/01/a7f8d9e2b4c6e1f3.jpg"
+// Saves as: "2024-01-a7f8d9e2b4c6e1f3.jpg"
 ```
 
 ### Using cURL

--- a/fixing_plan.md
+++ b/fixing_plan.md
@@ -55,10 +55,10 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
   - [x] Document `delete(url)` as the rollback-capable storage contract.
   - [x] Add tests for invalid MIME cleanup and post-upload DB/validation rollback cleanup.
 
-- [ ] Harden `LocalStorage` path containment.
-  - [ ] Sanitize or reject custom basenames containing `/`, `\`, drive prefixes, or empty names.
-  - [ ] Replace `startsWith(resolvedDir)` containment with `path.relative(resolvedDir, resolvedPath)`.
-  - [ ] Add tests for sibling-prefix traversal such as `../uploads_evil/pwn`.
+- [x] Harden `LocalStorage` path containment.
+  - [x] Sanitize or reject custom basenames containing `/`, `\`, drive prefixes, or empty names.
+  - [x] Replace `startsWith(resolvedDir)` containment with `path.relative(resolvedDir, resolvedPath)`.
+  - [x] Add tests for sibling-prefix traversal such as `../uploads_evil/pwn`.
 
 - [ ] Fix untrusted proxy URL generation. Requires maintainer approval.
   - [ ] Stop trusting `Host` and `X-Forwarded-*` by default for absolute links.

--- a/plugins/storage/local-storage.js
+++ b/plugins/storage/local-storage.js
@@ -19,6 +19,45 @@ export class LocalStorage {
     this.maxFilenameLength = options.maxFilenameLength || 255
   }
 
+  hasPathSegments (filename) {
+    return filename.includes('/') ||
+      filename.includes('\\') ||
+      path.isAbsolute(filename) ||
+      path.win32.isAbsolute(filename) ||
+      /^[A-Za-z]:/.test(filename)
+  }
+
+  validateCustomBasename (basename) {
+    if (typeof basename !== 'string') {
+      throw new Error('Custom nameGenerator must return a string')
+    }
+    if (basename.trim().length === 0) {
+      throw new Error('Custom nameGenerator must return a non-empty basename')
+    }
+    if (this.hasPathSegments(basename)) {
+      throw new Error('Custom nameGenerator must return a basename, not a path')
+    }
+    return basename
+  }
+
+  resolveStoragePath (filename) {
+    if (typeof filename !== 'string' || filename.trim().length === 0) {
+      throw new Error('Invalid file name')
+    }
+    if (this.hasPathSegments(filename)) {
+      throw new Error('Invalid file path')
+    }
+
+    const resolvedDir = path.resolve(this.directory)
+    const resolvedPath = path.resolve(resolvedDir, filename)
+    const relative = path.relative(resolvedDir, resolvedPath)
+    if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new Error('Invalid file path')
+    }
+
+    return resolvedPath
+  }
+
   /**
    * Generate a safe filename
    */
@@ -61,7 +100,7 @@ export class LocalStorage {
         if (!this.nameGenerator) {
           throw new Error('nameGenerator function required for custom strategy')
         }
-        basename = await this.nameGenerator(file)
+        basename = this.validateCustomBasename(await this.nameGenerator(file))
         break
 
       default:
@@ -107,7 +146,7 @@ export class LocalStorage {
    * Ensure filename is unique
    */
   async ensureUnique (filename) {
-    const filepath = path.join(this.directory, filename)
+    const filepath = this.resolveStoragePath(filename)
 
     try {
       await fs.access(filepath)
@@ -120,7 +159,7 @@ export class LocalStorage {
       do {
         newFilename = `${base}_${counter}${ext}`
         counter++
-      } while (await this.fileExists(path.join(this.directory, newFilename)))
+      } while (await this.fileExists(this.resolveStoragePath(newFilename)))
 
       return newFilename
     } catch (error) {
@@ -171,14 +210,7 @@ export class LocalStorage {
 
     // Generate secure filename
     const filename = await this.generateFilename(file)
-    const filepath = path.join(this.directory, filename)
-
-    // Ensure we're not writing outside our directory (defense in depth)
-    const resolvedPath = path.resolve(filepath)
-    const resolvedDir = path.resolve(this.directory)
-    if (!resolvedPath.startsWith(resolvedDir)) {
-      throw new Error('Invalid file path')
-    }
+    const filepath = this.resolveStoragePath(filename)
 
     // Write file
     if (file.data) {
@@ -198,14 +230,7 @@ export class LocalStorage {
    */
   async delete (url) {
     const filename = path.basename(url)
-    const filepath = path.join(this.directory, filename)
-
-    // Security check
-    const resolvedPath = path.resolve(filepath)
-    const resolvedDir = path.resolve(this.directory)
-    if (!resolvedPath.startsWith(resolvedDir)) {
-      throw new Error('Invalid file path')
-    }
+    const filepath = this.resolveStoragePath(filename)
 
     try {
       await fs.unlink(filepath)

--- a/tests/local-storage.test.js
+++ b/tests/local-storage.test.js
@@ -1,0 +1,96 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { LocalStorage } from '../plugins/storage/local-storage.js'
+
+let tempRoot
+
+async function createTempRoot () {
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'json-rest-api-local-storage-'))
+  return tempRoot
+}
+
+function createFile (filename = 'photo.png') {
+  return {
+    filename,
+    mimetype: 'image/png',
+    data: Buffer.from('x')
+  }
+}
+
+describe('LocalStorage path containment', () => {
+  beforeEach(async () => {
+    await createTempRoot()
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempRoot, { recursive: true, force: true })
+  })
+
+  it('rejects custom generated paths that escape to sibling directories', async () => {
+    const directory = path.join(tempRoot, 'uploads')
+    const evilDirectory = path.join(tempRoot, 'uploads_evil')
+    await fs.mkdir(evilDirectory, { recursive: true })
+
+    const storage = new LocalStorage({
+      directory,
+      fileBaseUrl: '/uploads',
+      nameStrategy: 'custom',
+      nameGenerator: async () => '../uploads_evil/pwn'
+    })
+
+    await assert.rejects(
+      storage.upload(createFile()),
+      /Custom nameGenerator must return a basename, not a path/
+    )
+
+    await assert.rejects(
+      fs.access(path.join(evilDirectory, 'pwn.png')),
+      { code: 'ENOENT' }
+    )
+  })
+
+  it('rejects empty and drive-prefixed custom generated names', async () => {
+    const directory = path.join(tempRoot, 'uploads')
+
+    const emptyNameStorage = new LocalStorage({
+      directory,
+      nameStrategy: 'custom',
+      nameGenerator: async () => '   '
+    })
+    await assert.rejects(
+      emptyNameStorage.upload(createFile()),
+      /Custom nameGenerator must return a non-empty basename/
+    )
+
+    const driveNameStorage = new LocalStorage({
+      directory,
+      nameStrategy: 'custom',
+      nameGenerator: async () => 'C:evil'
+    })
+    await assert.rejects(
+      driveNameStorage.upload(createFile()),
+      /Custom nameGenerator must return a basename, not a path/
+    )
+  })
+
+  it('keeps safe custom basenames inside the configured directory', async () => {
+    const directory = path.join(tempRoot, 'uploads')
+    const storage = new LocalStorage({
+      directory,
+      fileBaseUrl: '/uploads',
+      nameStrategy: 'custom',
+      nameGenerator: async () => 'avatar'
+    })
+
+    const firstUrl = await storage.upload(createFile())
+    const secondUrl = await storage.upload(createFile())
+
+    assert.equal(firstUrl, '/uploads/avatar.png')
+    assert.equal(secondUrl, '/uploads/avatar_1.png')
+    assert.equal(await fs.readFile(path.join(directory, 'avatar.png'), 'utf8'), 'x')
+    assert.equal(await fs.readFile(path.join(directory, 'avatar_1.png'), 'utf8'), 'x')
+  })
+})


### PR DESCRIPTION
## Summary
- reject path-like or empty custom LocalStorage generated names
- replace string-prefix containment checks with a shared path.relative-based resolver
- add sibling-prefix traversal tests for ../uploads_evil/pwn
- update file upload docs so custom names are basenames, not subpaths

## Verification
- node --test tests/local-storage.test.js
- npm run lint
- npm test
- npm run test:anyapi
- npm run verify
- npm run docs