### PR TITLE
Make field setter errors fail closed

### DIFF
--- a/docs/GUIDE/GUIDE_3_Field_Transformations.md
+++ b/docs/GUIDE/GUIDE_3_Field_Transformations.md
@@ -132,6 +132,8 @@ await api.addResource('users', {
 });
 ```
 
+If a setter throws or rejects, the write fails with a validation error and the transaction rolls back instead of storing the untransformed value.
+
 ### Getters - Transform After Retrieval
 
 ```javascript

--- a/fixing_plan.md
+++ b/fixing_plan.md
@@ -73,10 +73,10 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
 
 ## Low Priority
 
-- [ ] Make field setter errors fail closed.
-  - [ ] Change setter error handling to throw by default.
-  - [ ] Add an explicit opt-in non-fatal mode only if there is a real use case.
-  - [ ] Add a rollback test where a setter throws and no row is persisted.
+- [x] Make field setter errors fail closed.
+  - [x] Change setter error handling to throw by default.
+  - [x] Do not add an opt-in non-fatal mode without a real use case.
+  - [x] Add a rollback test where a setter throws and no row is persisted.
 
 - [ ] Normalize return-record boolean compatibility.
   - [ ] Create one shared return-record normalizer.

--- a/plugins/core/rest-api-plugin-methods/common.js
+++ b/plugins/core/rest-api-plugin-methods/common.js
@@ -570,8 +570,18 @@ export const applyFieldSetters = async (attributes, schemaInfo, context, api, he
         setterContext
       )
     } catch (error) {
-      console.warn(`Setter for field '${fieldName}' failed:`, error)
-      // Keep original value if setter fails
+      const message = error instanceof Error ? error.message : String(error)
+      throw new RestApiValidationError(
+        `Setter for field '${fieldName}' failed: ${message}`,
+        {
+          fields: [`data.attributes.${fieldName}`],
+          violations: [{
+            field: `data.attributes.${fieldName}`,
+            rule: 'setter_failed',
+            message
+          }]
+        }
+      )
     }
   }
 

--- a/tests/field-setters.test.js
+++ b/tests/field-setters.test.js
@@ -176,7 +176,7 @@ describe('Field Setters', () => {
       await cleanTables(knex, ['setter_users'])
     })
 
-    it('should handle setter errors gracefully', async () => {
+    it('should reject setter errors and roll back the write', async () => {
       // Create a resource with a failing setter
       await api.addResource('error_test', {
         schema: {
@@ -196,16 +196,16 @@ describe('Field Setters', () => {
       })
       await api.resources.error_test.createKnexTable()
 
-      const record = await api.resources.error_test.post({
-        good_field: 'HELLO',
-        bad_field: 'world'
-      })
+      await assert.rejects(
+        api.resources.error_test.post({
+          good_field: 'HELLO',
+          bad_field: 'world'
+        }),
+        /Setter for field 'bad_field' failed: Setter failed!/
+      )
 
-      const fetchedRecord = await api.resources.error_test.get({ id: record.id })
-      // Good field should be transformed
-      assert.equal(fetchedRecord.good_field, 'hello')
-      // Bad field should keep validated value (error logged but not thrown)
-      assert.equal(fetchedRecord.bad_field, 'world')
+      const records = await api.resources.error_test.query()
+      assert.equal(records?.length || 0, 0)
 
       await cleanTables(knex, ['setter_errors'])
     })


### PR DESCRIPTION
## Summary
- convert field setter exceptions into validation errors instead of storing the original value
- update the field-setter error test to assert rollback/no persisted row
- document setter failure rollback behavior and mark the plan item complete

## Verification
- node --test tests/field-setters.test.js
- JSON_REST_API_STORAGE=anyapi node --test tests/field-setters.test.js
- npm run lint
- npm test
- npm run test:anyapi
- npm run verify

Note: an initial parallel run of npm test and npm run test:anyapi was stopped because both suites include tests/curl.test.js on fixed port 3456; npm test was rerun standalone and passed.