### PR TITLE
Normalize return record settings

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -427,7 +427,7 @@ const result = await api.resources.[resourceType].post(params, context)
   },
   simplified: Boolean,      // Override simplified mode (default: true for API)
   transaction: Object,      // Database transaction object
-  returnFullRecord: String  // Override return setting ('no', 'minimal', 'full')
+  returnFullRecord: String|Boolean  // Override return setting ('no', 'minimal', 'full')
 }
 ```
 
@@ -443,7 +443,7 @@ const result = await api.resources.[resourceType].post(params, context)
 | `queryParams` | Object | No | For includes/fields in response |
 | `simplified` | Boolean | No | Override simplified mode (default: true) |
 | `transaction` | Object | No | Database transaction object |
-| `returnFullRecord` | String | No | Override return setting ('no', 'minimal', 'full') |
+| `returnFullRecord` | String\|Boolean | No | Override return setting (`'no'`, `'minimal'`, `'full'`; legacy `true` = `'full'`, `false` = `'no'`) |
 
 When an explicit resource id is provided, `normalizeId` runs before persistence and before any follow-up record fetch used for the return payload. If the normalized id is empty, the request fails as `REST_API_VALIDATION` on `data.id`.
 
@@ -459,6 +459,8 @@ The return value depends on `returnFullRecord` setting and whether it's an API o
 - `'no'`: Returns `undefined` (204 No Content)
 - `'minimal'`: Returns resource with ID only
 - `'full'`: Returns complete resource with all fields
+
+Boolean values are accepted for backward compatibility: `true` is normalized to `'full'` and `false` is normalized to `'no'`. New code should use the string values.
 
 #### HTTP Equivalent
 
@@ -611,7 +613,7 @@ const result = await api.resources.[resourceType].put(params, context)
   },
   simplified: Boolean,      // Override simplified mode (default: true for API)
   transaction: Object,      // Database transaction object
-  returnFullRecord: String  // Override return setting ('no', 'minimal', 'full')
+  returnFullRecord: String|Boolean  // Override return setting ('no', 'minimal', 'full')
 }
 ```
 
@@ -626,7 +628,7 @@ const result = await api.resources.[resourceType].put(params, context)
 | `queryParams` | Object | No | For response formatting |
 | `simplified` | Boolean | No | Override simplified mode (default: true) |
 | `transaction` | Object | No | Database transaction object |
-| `returnFullRecord` | String | No | Override return setting |
+| `returnFullRecord` | String\|Boolean | No | Override return setting (`'no'`, `'minimal'`, `'full'`; legacy `true` = `'full'`, `false` = `'no'`) |
 
 `inputRecord.id` and `inputRecord.data.id` always refer to the logical resource id. `idProperty` and storage mapping affect the backing column name, not the API field name, and the resource id is not part of `attributes`.
 
@@ -742,7 +744,7 @@ const result = await api.resources.[resourceType].patch(params, context)
   },
   simplified: Boolean,      // Override simplified mode (default: true for API)
   transaction: Object,      // Database transaction object
-  returnFullRecord: String  // Override return setting ('no', 'minimal', 'full')
+  returnFullRecord: String|Boolean  // Override return setting ('no', 'minimal', 'full')
 }
 ```
 
@@ -757,7 +759,7 @@ const result = await api.resources.[resourceType].patch(params, context)
 | `queryParams` | Object | No | For response formatting |
 | `simplified` | Boolean | No | Override simplified mode (default: true) |
 | `transaction` | Object | No | Database transaction object |
-| `returnFullRecord` | String | No | Override return setting |
+| `returnFullRecord` | String\|Boolean | No | Override return setting (`'no'`, `'minimal'`, `'full'`; legacy `true` = `'full'`, `false` = `'no'`) |
 
 If both the URL id and body id are present, both are normalized before the equality check. If either id normalizes to an empty value, the operation fails before storage is touched.
 

--- a/docs/GUIDE/GUIDE_1_Initial_Setup.md
+++ b/docs/GUIDE/GUIDE_1_Initial_Setup.md
@@ -340,10 +340,12 @@ There are TWO separate settings for this:
 
 This separation allows you to have different behaviors for internal API usage versus external HTTP clients. For example, your internal code might want full records for convenience, while HTTP clients might prefer minimal responses for performance.
 
-Both settings accept three string values:
+Both settings prefer three string values:
 - **`'full'`**: Returns the complete record with all attributes, relationships, computed fields, and links
 - **`'minimal'`**: Returns only the resource type and ID
 - **`'no'`**: Returns nothing (undefined in programmatic calls, 204 No Content in HTTP)
+
+Boolean values are accepted for backward compatibility: `true` is normalized to `'full'` and `false` is normalized to `'no'`. New code should use the string values.
 
 Here's how these settings work:
 
@@ -796,6 +798,7 @@ Here is a full list of parameters and their respective variables:
 - `returnRecordApi` and `returnRecordTransport` can be either:
   - A string: `'no'`, `'minimal'`, or `'full'` (applies to all methods)
   - An object: `{ post: 'full', put: 'minimal', patch: 'no' }` (per-method configuration)
+  - Legacy booleans: `true` is treated as `'full'`, `false` as `'no'`
 - All parameters support the cascade: per-call → resource-level → plugin-level default
 
 # Logical IDs and Physical Columns

--- a/fixing_plan.md
+++ b/fixing_plan.md
@@ -78,11 +78,11 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
   - [x] Do not add an opt-in non-fatal mode without a real use case.
   - [x] Add a rollback test where a setter throws and no row is persisted.
 
-- [ ] Normalize return-record boolean compatibility.
-  - [ ] Create one shared return-record normalizer.
-  - [ ] Normalize `true -> 'full'`, `false -> 'no'`, and keep valid strings unchanged.
-  - [ ] Use the shared normalizer in plugin install and per-call setup.
-  - [ ] Update tests and docs to prefer `'no'`, `'minimal'`, and `'full'` while preserving boolean compatibility.
+- [x] Normalize return-record boolean compatibility.
+  - [x] Create one shared return-record normalizer.
+  - [x] Normalize `true -> 'full'`, `false -> 'no'`, and keep valid strings unchanged.
+  - [x] Use the shared normalizer in plugin install and per-call setup.
+  - [x] Update tests and docs to prefer `'no'`, `'minimal'`, and `'full'` while preserving boolean compatibility.
 
 ## Contract Drift
 

--- a/plugins/core/bulk-operations-plugin.js
+++ b/plugins/core/bulk-operations-plugin.js
@@ -193,11 +193,12 @@ export const BulkOperationsPlugin = {
               transaction
             }, recordContext)
 
-            // If patch doesn't return full record, fetch it
-            let resultData = result.data
-            if (!resultData && result.id) {
+            // If patch doesn't return a full record, fetch the updated record.
+            const resultId = result?.data?.id || result?.id || operation.id
+            let resultData = result?.data
+            if (!resultData && resultId) {
               const fetchedRecord = await scope.get({
-                id: result.id,
+                id: resultId,
                 transaction
               }, recordContext)
               resultData = fetchedRecord.data

--- a/plugins/core/lib/querying-writing/return-record-settings.js
+++ b/plugins/core/lib/querying-writing/return-record-settings.js
@@ -1,0 +1,47 @@
+const RETURN_RECORD_METHODS = ['post', 'put', 'patch']
+const RETURN_RECORD_MODES = ['no', 'minimal', 'full']
+
+export function normalizeReturnRecordMode (value, defaultValue = 'no') {
+  if (value === true) return 'full'
+  if (value === false) return 'no'
+  if (RETURN_RECORD_MODES.includes(value)) return value
+
+  if (defaultValue === true) return 'full'
+  if (defaultValue === false) return 'no'
+  if (RETURN_RECORD_MODES.includes(defaultValue)) return defaultValue
+
+  return 'no'
+}
+
+function defaultModeForMethod (defaultValue, method) {
+  if (defaultValue && typeof defaultValue === 'object' && !Array.isArray(defaultValue)) {
+    return normalizeReturnRecordMode(defaultValue[method], 'no')
+  }
+
+  return normalizeReturnRecordMode(defaultValue, 'no')
+}
+
+export function normalizeReturnRecordSetting (value, defaultValue = 'no') {
+  if (value === undefined) {
+    return Object.fromEntries(
+      RETURN_RECORD_METHODS.map(method => [
+        method,
+        defaultModeForMethod(defaultValue, method)
+      ])
+    )
+  }
+
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return Object.fromEntries(
+      RETURN_RECORD_METHODS.map(method => [
+        method,
+        normalizeReturnRecordMode(value[method], defaultModeForMethod(defaultValue, method))
+      ])
+    )
+  }
+
+  const normalized = normalizeReturnRecordMode(value, defaultModeForMethod(defaultValue, 'post'))
+  return Object.fromEntries(
+    RETURN_RECORD_METHODS.map(method => [method, normalized])
+  )
+}

--- a/plugins/core/rest-api-plugin-hooks/turn-scope-init-into-vars.js
+++ b/plugins/core/rest-api-plugin-hooks/turn-scope-init-into-vars.js
@@ -1,3 +1,5 @@
+import { normalizeReturnRecordSetting } from '../lib/querying-writing/return-record-settings.js'
+
 export default async function turnScopeInitIntoVars ({ context, scopes, vars: apiVars }) {
   // Refer to the scope's vars
   const scope = scopes[context.scopeName]
@@ -19,8 +21,12 @@ export default async function turnScopeInitIntoVars ({ context, scopes, vars: ap
   if (typeof scopeOptions.simplifiedTransport !== 'undefined') vars.simplifiedTransport = scopeOptions.simplifiedTransport
 
   // Set returnRecord settings as scope vars
-  if (typeof scopeOptions.returnRecordApi !== 'undefined') vars.returnRecordApi = scopeOptions.returnRecordApi
-  if (typeof scopeOptions.returnRecordTransport !== 'undefined') vars.returnRecordTransport = scopeOptions.returnRecordTransport
+  if (typeof scopeOptions.returnRecordApi !== 'undefined') {
+    vars.returnRecordApi = normalizeReturnRecordSetting(scopeOptions.returnRecordApi, vars.returnRecordApi || 'full')
+  }
+  if (typeof scopeOptions.returnRecordTransport !== 'undefined') {
+    vars.returnRecordTransport = normalizeReturnRecordSetting(scopeOptions.returnRecordTransport, vars.returnRecordTransport || 'no')
+  }
 
   // Set idProperty as scope var
   if (typeof scopeOptions.idProperty !== 'undefined') vars.idProperty = scopeOptions.idProperty

--- a/plugins/core/rest-api-plugin-methods/common.js
+++ b/plugins/core/rest-api-plugin-methods/common.js
@@ -6,6 +6,12 @@ import { transformSimplifiedToJsonApi } from '../lib/querying-writing/simplified
 import { normalizeRelationshipIdentifiers } from '../lib/querying-writing/resource-id-normalization.js'
 import { createEnhancedLogger } from '../../../lib/enhanced-logger.js'
 import { unwrapQueryBuilderState } from '../lib/querying/query-builder-utils.js'
+import {
+  normalizeReturnRecordMode,
+  normalizeReturnRecordSetting
+} from '../lib/querying-writing/return-record-settings.js'
+
+export { normalizeReturnRecordMode as normalizeReturnValue }
 
 /**
  * Gets an enhanced logger instance with full error details and stack traces
@@ -28,16 +34,6 @@ export const getEnhancedLogger = (log) => {
  */
 export const cascadeConfig = (settingName, sources, defaultValue) =>
   sources.find(source => source?.[settingName] !== undefined)?.[settingName] ?? defaultValue
-
-/**
- * Normalizes return record settings to valid values
- * @param {string|boolean} value - The value to normalize
- * @returns {string} Normalized value: 'no', 'minimal', or 'full'
- */
-export function normalizeReturnValue (value) {
-  if (['no', 'minimal', 'full'].includes(value)) return value
-  return 'no' // default
-}
 
 /**
  * Sets up common request context for REST API methods
@@ -76,7 +72,7 @@ export async function setupCommonRequest ({ params, context, vars, scopes, scope
     } else {
       context.inputRecord = params
       // Preserve returnFullRecord if specified in params
-      context.params = params.returnFullRecord ? { returnFullRecord: params.returnFullRecord } : {}
+      context.params = params.returnFullRecord !== undefined ? { returnFullRecord: params.returnFullRecord } : {}
     }
   } else {
     context.inputRecord = params.inputRecord
@@ -90,33 +86,10 @@ export async function setupCommonRequest ({ params, context, vars, scopes, scope
   const defaultReturnFullRecord = isTransport ? vars.returnRecordTransport : vars.returnRecordApi
 
   // Get return record setting - from params only (per-call override) or use default
-  const returnFullRecordRaw = context.params.returnFullRecord !== undefined
-    ? context.params.returnFullRecord
-    : defaultReturnFullRecord
-
-  // Normalize return record setting to always be an object with method keys
-  if (typeof returnFullRecordRaw === 'object' && returnFullRecordRaw !== null) {
-    // It's already an object, normalize the values
-    context.returnRecordSetting = {
-      post: normalizeReturnValue(returnFullRecordRaw.post),
-      put: normalizeReturnValue(returnFullRecordRaw.put),
-      patch: normalizeReturnValue(returnFullRecordRaw.patch)
-    }
-  } else {
-    // It's a single value (string or boolean), apply to all methods
-    const normalized = normalizeReturnValue(returnFullRecordRaw)
-    context.returnRecordSetting = {
-      post: normalized,
-      put: normalized,
-      patch: normalized
-    }
-  }
-
-  // Helper function to normalize return values (same as above)
-  function normalizeReturnValue (value) {
-    if (['no', 'minimal', 'full'].includes(value)) return value
-    return 'no' // default
-  }
+  context.returnRecordSetting = normalizeReturnRecordSetting(
+    context.params.returnFullRecord,
+    defaultReturnFullRecord
+  )
 
   // These only make sense as parameter per query, not in vars etc.
   context.queryParams = params.queryParams || {}

--- a/plugins/core/rest-api-plugin.js
+++ b/plugins/core/rest-api-plugin.js
@@ -21,6 +21,7 @@ import addRouteMethod from './rest-api-plugin-methods/add-route.js'
 import releaseMethod from './rest-api-plugin-methods/release.js'
 import { defaultDataHelpers } from './lib/querying-writing/default-data-helpers.js'
 import { DEFAULT_QUERY_LIMIT, DEFAULT_MAX_QUERY_LIMIT, DEFAULT_INCLUDE_DEPTH_LIMIT } from './lib/querying-writing/knex-constants.js'
+import { normalizeReturnRecordSetting } from './lib/querying-writing/return-record-settings.js'
 
 import getRelatedMethod from './rest-api-plugin-methods/get-related.js'
 import postRelationshipMethod from './rest-api-plugin-methods/post-relationship.js'
@@ -71,42 +72,11 @@ export const RestApiPlugin = {
       ? restApiOptions.normalizeId
       : defaultNormalizeResourceId
 
-    // Return full record configuration for API and Transport
-    // Support values: 'no', 'minimal', 'full'
-    const normalizeReturnValue = (value, defaultValue) => {
-      if (['no', 'minimal', 'full'].includes(value)) return value
-      return defaultValue
-    }
-
-    const optionConfigs = [
-      {
-        propName: 'returnRecordApi',
-        defaultValue: 'full',
-      },
-      {
-        propName: 'returnRecordTransport',
-        defaultValue: 'no',
-      },
-    ]
-
-    for (const config of optionConfigs) {
-      const optionValue = restApiOptions[config.propName]
-      let processedValue
-
-      if (typeof optionValue === 'object' && optionValue !== null) {
-        processedValue = {
-          post: normalizeReturnValue(optionValue.post, config.defaultValue),
-          put: normalizeReturnValue(optionValue.put, config.defaultValue),
-          patch: normalizeReturnValue(optionValue.patch, config.defaultValue),
-        }
-      } else if (optionValue !== undefined) {
-        const normalized = normalizeReturnValue(optionValue, config.defaultValue)
-        processedValue = { post: normalized, put: normalized, patch: normalized }
-      } else {
-        processedValue = { post: config.defaultValue, put: config.defaultValue, patch: config.defaultValue }
-      }
-      vars[config.propName] = processedValue
-    }
+    // Return record configuration for API and Transport.
+    // Preferred values are 'no', 'minimal', and 'full'; booleans are normalized
+    // for backwards compatibility.
+    vars.returnRecordApi = normalizeReturnRecordSetting(restApiOptions.returnRecordApi, 'full')
+    vars.returnRecordTransport = normalizeReturnRecordSetting(restApiOptions.returnRecordTransport, 'no')
 
     log.debug('returnRecordApi configuration:', vars.returnRecordApi)
     log.debug('returnRecordTransport configuration:', vars.returnRecordTransport)

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,7 +20,7 @@ All tests MUST use `simplified: false` to ensure JSON:API compliance:
 const result = await api.resources.resourceName.method({
   inputRecord: jsonApiDocument,
   simplified: false,
-  returnFullRecord: true/false  // Based on needs
+  returnFullRecord: 'full' // Use 'no', 'minimal', or 'full' based on needs
 });
 ```
 

--- a/tests/fixtures/api-configs.js
+++ b/tests/fixtures/api-configs.js
@@ -198,6 +198,80 @@ export async function createBasicApi (knex, pluginOptions = {}) {
   }
 }
 
+export async function createReturnRecordApi (knex, pluginOptions = {}) {
+  const apiName = pluginOptions.apiName || 'return-record-test-api'
+  const tablePrefix = pluginOptions.tablePrefix || 'return'
+  if (storageMode.isAnyApi()) {
+    storageMode.clearRegistry()
+  }
+
+  const api = new Api({
+    name: apiName,
+    log: { level: process.env.LOG_LEVEL || 'info' }
+  })
+
+  const previousTenant = storageMode.currentTenant
+  const tenantId = storageMode.isAnyApi()
+    ? (pluginOptions.tenantId || `${tablePrefix}_tenant`)
+    : storageMode.defaultTenant
+  if (storageMode.isAnyApi()) {
+    storageMode.setCurrentTenant(tenantId)
+  }
+
+  await api.use(RestApiPlugin, {
+    simplifiedApi: false,
+    simplifiedTransport: false,
+    returnRecordApi: {
+      post: true,
+      put: false,
+      patch: false
+    },
+    returnRecordTransport: {
+      post: false,
+      put: true,
+      patch: 'minimal'
+    },
+    sortableFields: ['id', 'name'],
+    ...pluginOptions['rest-api']
+  })
+  await useStoragePlugin(api, knex, { tenantId })
+  await resetAnyApiTables(knex)
+
+  try {
+    await api.addResource('global_items', {
+      schema: {
+        id: { type: 'id' },
+        name: { type: 'string', required: true, max: 100 }
+      },
+      tableName: `${tablePrefix}_global_items`
+    })
+    await api.resources.global_items.createKnexTable()
+    mapTable(`${tablePrefix}_global_items`, 'global_items')
+
+    await api.addResource('scope_items', {
+      schema: {
+        id: { type: 'id' },
+        name: { type: 'string', required: true, max: 100 }
+      },
+      tableName: `${tablePrefix}_scope_items`,
+      returnRecordApi: {
+        post: false,
+        put: true,
+        patch: 'minimal'
+      },
+      returnRecordTransport: true
+    })
+    await api.resources.scope_items.createKnexTable()
+    mapTable(`${tablePrefix}_scope_items`, 'scope_items')
+  } finally {
+    if (storageMode.isAnyApi()) {
+      storageMode.setCurrentTenant(previousTenant)
+    }
+  }
+
+  return api
+}
+
 /**
  * Creates a small API that uses logical camelCase belongsTo fields with default snake_case storage mapping.
  * This reproduces the full JSON:API linkage path where storage column names differ from logical field names.

--- a/tests/full-jsonapi-belongsto-linkage.test.js
+++ b/tests/full-jsonapi-belongsto-linkage.test.js
@@ -102,7 +102,8 @@ describe('Full JSON:API belongsTo linkage', () => {
       queryParams: {
         include: ['country']
       },
-      simplified: false
+      simplified: false,
+      returnFullRecord: 'full'
     })
 
     assertResourceRelationship(
@@ -131,7 +132,8 @@ describe('Full JSON:API belongsTo linkage', () => {
           }
         }
       },
-      simplified: false
+      simplified: false,
+      returnFullRecord: 'full'
     })
 
     assert.equal(patched.data.relationships?.country?.data, null)

--- a/tests/return-record-settings.test.js
+++ b/tests/return-record-settings.test.js
@@ -1,0 +1,184 @@
+import { describe, it, before, after, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import knexLib from 'knex'
+import { createReturnRecordApi } from './fixtures/api-configs.js'
+import { cleanTables } from './helpers/test-utils.js'
+
+const knex = knexLib({
+  client: 'better-sqlite3',
+  connection: {
+    filename: ':memory:'
+  },
+  useNullAsDefault: true
+})
+
+let api
+
+function itemDocument (type, name, id) {
+  const doc = {
+    data: {
+      type,
+      attributes: { name }
+    }
+  }
+
+  if (id !== undefined) {
+    doc.data.id = String(id)
+  }
+
+  return doc
+}
+
+describe('Return record settings', () => {
+  before(async () => {
+    api = await createReturnRecordApi(knex)
+  })
+
+  after(async () => {
+    await knex.destroy()
+  })
+
+  beforeEach(async () => {
+    await cleanTables(knex, [
+      'return_global_items',
+      'return_scope_items'
+    ])
+  })
+
+  it('normalizes plugin-level boolean return settings', async () => {
+    const created = await api.resources.global_items.post({
+      inputRecord: itemDocument('global_items', 'Global Created'),
+      simplified: false
+    })
+
+    assert.equal(created.data.type, 'global_items')
+    assert.equal(created.data.attributes.name, 'Global Created')
+
+    const replaced = await api.resources.global_items.put({
+      id: created.data.id,
+      inputRecord: itemDocument('global_items', 'Global Replaced', created.data.id),
+      simplified: false
+    })
+    assert.equal(replaced, undefined)
+
+    const patched = await api.resources.global_items.patch({
+      id: created.data.id,
+      inputRecord: itemDocument('global_items', 'Global Patched', created.data.id),
+      simplified: false
+    })
+    assert.equal(patched, undefined)
+
+    const fetched = await api.resources.global_items.get({
+      id: created.data.id,
+      simplified: false
+    })
+    assert.equal(fetched.data.attributes.name, 'Global Patched')
+  })
+
+  it('normalizes per-call boolean return settings', async () => {
+    const created = await api.resources.global_items.post({
+      inputRecord: itemDocument('global_items', 'Per-call Created'),
+      simplified: false,
+      returnFullRecord: false
+    })
+    assert.equal(created, undefined)
+
+    const queryResult = await api.resources.global_items.query({
+      simplified: false
+    })
+    assert.equal(queryResult.data.length, 1)
+    const fetched = queryResult.data[0]
+    assert.equal(fetched.attributes.name, 'Per-call Created')
+
+    const patched = await api.resources.global_items.patch({
+      id: fetched.id,
+      inputRecord: itemDocument('global_items', 'Per-call Patched', fetched.id),
+      simplified: false,
+      returnFullRecord: true
+    })
+    assert.equal(patched.data.type, 'global_items')
+    assert.equal(patched.data.id, fetched.id)
+    assert.equal(patched.data.attributes.name, 'Per-call Patched')
+  })
+
+  it('normalizes resource-level boolean return settings', async () => {
+    const created = await api.resources.scope_items.post({
+      inputRecord: itemDocument('scope_items', 'Scoped Created'),
+      simplified: false
+    })
+    assert.equal(created, undefined)
+
+    const queryResult = await api.resources.scope_items.query({
+      simplified: false
+    })
+    assert.equal(queryResult.data.length, 1)
+    const fetched = queryResult.data[0]
+
+    const replaced = await api.resources.scope_items.put({
+      id: fetched.id,
+      inputRecord: itemDocument('scope_items', 'Scoped Replaced', fetched.id),
+      simplified: false
+    })
+    assert.equal(replaced.data.type, 'scope_items')
+    assert.equal(replaced.data.id, fetched.id)
+    assert.equal(replaced.data.attributes.name, 'Scoped Replaced')
+
+    const patched = await api.resources.scope_items.patch({
+      id: fetched.id,
+      inputRecord: itemDocument('scope_items', 'Scoped Patched', fetched.id),
+      simplified: false
+    })
+    assert.deepEqual(patched, {
+      data: {
+        type: 'scope_items',
+        id: fetched.id
+      }
+    })
+  })
+
+  it('normalizes transport boolean return settings', async () => {
+    const created = await api.resources.global_items.post({
+      inputRecord: itemDocument('global_items', 'Transport Created'),
+      simplified: false,
+      isTransport: true
+    })
+    assert.equal(created, undefined)
+
+    const queryResult = await api.resources.global_items.query({
+      simplified: false
+    })
+    assert.equal(queryResult.data.length, 1)
+    const fetched = queryResult.data[0]
+
+    const replaced = await api.resources.global_items.put({
+      id: fetched.id,
+      inputRecord: itemDocument('global_items', 'Transport Replaced', fetched.id),
+      simplified: false,
+      isTransport: true
+    })
+    assert.equal(replaced.data.type, 'global_items')
+    assert.equal(replaced.data.id, fetched.id)
+    assert.equal(replaced.data.attributes.name, 'Transport Replaced')
+
+    const patched = await api.resources.global_items.patch({
+      id: fetched.id,
+      inputRecord: itemDocument('global_items', 'Transport Patched', fetched.id),
+      simplified: false,
+      isTransport: true
+    })
+    assert.deepEqual(patched, {
+      data: {
+        type: 'global_items',
+        id: fetched.id
+      }
+    })
+
+    const scoped = await api.resources.scope_items.post({
+      inputRecord: itemDocument('scope_items', 'Scoped Transport Created'),
+      simplified: false,
+      isTransport: true
+    })
+    assert.equal(scoped.data.type, 'scope_items')
+    assert.equal(scoped.data.attributes.name, 'Scoped Transport Created')
+  })
+})

--- a/tests/test-development-guide.md
+++ b/tests/test-development-guide.md
@@ -64,9 +64,9 @@ Control what methods return:
 ```javascript
 // In API configuration
 returnFullRecord: {
-  post: true,   // Return created record (needed to get ID)
-  put: false,   // Don't return after replacement
-  patch: false  // Don't return after update
+  post: 'full', // Return created record (needed to get ID)
+  put: 'no',    // Don't return after replacement
+  patch: 'no'   // Don't return after update
 }
 
 // Override per call if needed
@@ -74,7 +74,7 @@ const result = await api.resources.books.put({
   id: bookId,
   inputRecord: putDoc,
   simplified: false,
-  returnFullRecord: false  // Override to not return
+  returnFullRecord: 'no' // Override to not return
 });
 ```
 


### PR DESCRIPTION
## Summary
- add a shared return-record normalizer for plugin, resource, transport, and per-call settings
- preserve legacy boolean compatibility with true -> full and false -> no
- update bulk patch and focused tests/docs to use the normalized contract explicitly

## Verification
- node --test tests/return-record-settings.test.js
- JSON_REST_API_STORAGE=anyapi node --test tests/return-record-settings.test.js
- npm run lint
- npm test
- npm run test:anyapi
- npm run verify