### PR TITLE
Export SocketIO plugin publicly

### DIFF
--- a/docs/GUIDE/GUIDE_X_SocketIO.md
+++ b/docs/GUIDE/GUIDE_X_SocketIO.md
@@ -30,19 +30,17 @@ The Socket.IO plugin provides real-time notifications when resources change in y
 
 The Socket.IO plugin is included in json-rest-api core plugins. To use it, you need to:
 
-1. Install Socket.IO dependencies:
+1. Install Socket.IO. Redis packages are only needed when you configure the Redis adapter:
 ```bash
-npm install socket.io @socket.io/redis-adapter redis
+npm install socket.io
+npm install @socket.io/redis-adapter redis
 ```
 
 2. Use the plugin and start the Socket.IO server:
 
 ```javascript
-import { Api } from 'json-rest-api';
-import { RestApiPlugin } from 'json-rest-api/plugins/rest-api';
-import { RestApiKnexPlugin } from 'json-rest-api/plugins/rest-api-knex';
-import { SocketIOPlugin } from 'json-rest-api/plugins/socketio';
-import { JWTAuthPlugin } from 'json-rest-api/plugins/jwt-auth';
+import { Api } from 'hooked-api';
+import { RestApiPlugin, RestApiKnexPlugin, SocketIOPlugin } from 'json-rest-api';
 
 // Create your API instance
 const api = new Api({
@@ -52,8 +50,15 @@ const api = new Api({
 // Add required plugins
 await api.use(RestApiPlugin);
 await api.use(RestApiKnexPlugin, { knex: knexInstance });
-await api.use(JWTAuthPlugin, { secret: process.env.JWT_SECRET });
-await api.use(SocketIOPlugin);
+await api.use(SocketIOPlugin, {
+  auth: {
+    requireAuth: true,
+    authenticate: async ({ socket }) => {
+      const token = socket.handshake.auth?.token;
+      return verifyToken(token); // App-defined token verification
+    }
+  }
+});
 
 // Start your HTTP server
 const server = app.listen(3000).on('error', (err) => {

--- a/fixing_plan.md
+++ b/fixing_plan.md
@@ -86,11 +86,11 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
 
 ## Contract Drift
 
-- [ ] Fix Socket.IO public exports and docs.
-  - [ ] Export `SocketIOPlugin` from `index.js`.
-  - [ ] Fix docs to import `Api` from `hooked-api`, not `json-rest-api`.
-  - [ ] Remove invalid deep imports such as `json-rest-api/plugins/socketio`, or add formal package subpath exports. Subpath exports require maintainer approval.
-  - [ ] Add a public import smoke test.
+- [x] Fix Socket.IO public exports and docs.
+  - [x] Export `SocketIOPlugin` from `index.js`.
+  - [x] Fix docs to import `Api` from `hooked-api`, not `json-rest-api`.
+  - [x] Remove invalid deep imports such as `json-rest-api/plugins/socketio`, or add formal package subpath exports. Subpath exports require maintainer approval.
+  - [x] Add a public import smoke test.
 
 - [ ] Align S3 documentation with implementation.
   - [ ] If real S3 is not implemented, make README and guide text state that the included adapter is mock/demo only.
@@ -109,4 +109,4 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
 - [x] Narrow repro for AnyAPI custom `idProperty`
 - [x] Narrow repro for relationship route `afterCommit`
 - [x] Narrow repro for pagination link round trip
-- [ ] Import smoke test for public exports
+- [x] Import smoke test for public exports

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ export { QueryProjectionsPlugin } from './plugins/core/rest-api-query-projection
 export { FileHandlingPlugin } from './plugins/core/file-handling-plugin.js'
 export { CorsPlugin } from './plugins/core/rest-api-cors-plugin.js'
 export { LabelPlugin } from './plugins/core/rest-api-label-plugin.js'
+export { SocketIOPlugin } from './plugins/core/socketio-plugin.js'
 
 // Database plugins
 export { RestApiKnexPlugin } from './plugins/core/rest-api-knex-plugin.js'

--- a/tests/fixtures/api-configs.js
+++ b/tests/fixtures/api-configs.js
@@ -1,5 +1,5 @@
 import { Api } from 'hooked-api'
-import { RestApiPlugin, RestApiKnexPlugin, RestApiAnyapiKnexPlugin, QueryProjectionsPlugin, FileHandlingPlugin } from '../../index.js'
+import { RestApiPlugin, RestApiKnexPlugin, RestApiAnyapiKnexPlugin, QueryProjectionsPlugin, FileHandlingPlugin, SocketIOPlugin } from '../../index.js'
 import { ExpressPlugin } from '../../plugins/core/connectors/express-plugin.js'
 import express from 'express'
 import { createServer } from 'http'
@@ -848,7 +848,6 @@ export async function createPaginationApi (knex, options = {}) {
  * Creates an API with WebSocket/Socket.IO support for testing
  */
 export async function createWebSocketApi (knex, pluginOptions = {}) {
-  const { SocketIOPlugin } = await import('../../plugins/core/socketio-plugin.js')
   const { jwtVerify } = await import('jose')
 
   const api = await createBasicApi(knex, {

--- a/tests/public-exports.test.js
+++ b/tests/public-exports.test.js
@@ -1,0 +1,10 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { SocketIOPlugin } from '../index.js'
+
+describe('Public exports', () => {
+  it('exports the documented Socket.IO plugin from the package entrypoint', () => {
+    assert.equal(SocketIOPlugin.name, 'socketio')
+    assert.equal(typeof SocketIOPlugin.install, 'function')
+  })
+})


### PR DESCRIPTION
## Summary
- export SocketIOPlugin from the package entrypoint
- update the Socket.IO guide to use public imports and hooked-api for Api
- add a public export smoke test and dogfood the public SocketIO export in test fixtures

## Verification
- node --test tests/public-exports.test.js tests/socketio.test.js
- JSON_REST_API_STORAGE=anyapi node --test tests/public-exports.test.js tests/socketio.test.js
- npm run lint
- npm test
- npm run test:anyapi
- npm run verify