### PR TITLE
Consolidate relationship route contracts

### DIFF
--- a/fixing_plan.md
+++ b/fixing_plan.md
@@ -96,9 +96,9 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
   - [ ] If real S3 is not implemented, make README and guide text state that the included adapter is mock/demo only.
   - [ ] If real S3 is implemented, update docs and tests to match the production behavior.
 
-- [ ] Finish relationship validation contract consolidation.
-  - [ ] Move relationship-route schemas into the same request-contract surface as resource routes.
-  - [ ] Do this after the cardinality fix so the centralized contract is correct rather than merely centralized.
+- [x] Finish relationship validation contract consolidation.
+  - [x] Move relationship-route schemas into the same request-contract surface as resource routes.
+  - [x] Do this after the cardinality fix so the centralized contract is correct rather than merely centralized.
 
 ## Verification Checklist
 

--- a/plugins/core/connectors/lib/transport-route-schemas.js
+++ b/plugins/core/connectors/lib/transport-route-schemas.js
@@ -1,70 +1,11 @@
 import { getRequestContracts } from '../../lib/querying-writing/request-contracts.js'
 
-const STRING_OR_NUMBER_SCHEMA = {
-  anyOf: [
-    { type: 'string' },
-    { type: 'number' }
-  ]
-}
-
-function buildResourceIdentifierSchema () {
-  return {
-    type: 'object',
-    additionalProperties: false,
-    required: ['type', 'id'],
-    properties: {
-      type: { type: 'string', minLength: 1 },
-      id: STRING_OR_NUMBER_SCHEMA
-    }
-  }
-}
-
-function buildRelationshipValueSchema (operation) {
-  if (operation === 'patchRelationship') {
-    return {
-      anyOf: [
-        { type: 'null' },
-        buildResourceIdentifierSchema(),
-        {
-          type: 'array',
-          items: buildResourceIdentifierSchema()
-        }
-      ]
-    }
-  }
-
-  return {
-    type: 'array',
-    items: buildResourceIdentifierSchema()
-  }
-}
-
-function buildRelationshipRouteBodySchema (operation) {
-  if (!['postRelationship', 'patchRelationship', 'deleteRelationship'].includes(operation)) {
-    return null
-  }
-
-  return {
-    type: 'object',
-    additionalProperties: false,
-    required: ['data'],
-    properties: {
-      data: buildRelationshipValueSchema(operation)
-    }
-  }
-}
-
 export function buildTransportRouteSchema ({ routeMeta, api }) {
   if (!routeMeta) {
     return null
   }
 
-  if (routeMeta.kind === 'relationship') {
-    const relationshipBodySchema = buildRelationshipRouteBodySchema(routeMeta.operation)
-    return relationshipBodySchema ? { body: relationshipBodySchema } : null
-  }
-
-  if (routeMeta.kind !== 'resource' || !['post', 'put', 'patch'].includes(routeMeta.operation)) {
+  if (!['resource', 'relationship'].includes(routeMeta.kind)) {
     return null
   }
 
@@ -83,6 +24,17 @@ export function buildTransportRouteSchema ({ routeMeta, api }) {
 
   const contract = requestContracts[routeMeta.operation]
   if (!contract?.schema) {
+    return null
+  }
+
+  if (routeMeta.kind === 'resource' && !['post', 'put', 'patch'].includes(routeMeta.operation)) {
+    return null
+  }
+
+  if (
+    routeMeta.kind === 'relationship' &&
+    !['postRelationship', 'patchRelationship', 'deleteRelationship'].includes(routeMeta.operation)
+  ) {
     return null
   }
 

--- a/plugins/core/lib/querying-writing/request-contracts.js
+++ b/plugins/core/lib/querying-writing/request-contracts.js
@@ -550,6 +550,22 @@ function buildQueryRequestContract ({ includeDepthLimit, sortableFields, searchS
   }
 }
 
+function buildRelationshipRouteBodyContract (operation) {
+  const isPatch = operation === 'patchRelationship'
+
+  return {
+    schema: createSchema({
+      data: {
+        type: 'jsonApiRelationshipData',
+        required: true,
+        nullable: isPatch,
+        cardinality: isPatch ? null : 'many'
+      }
+    }),
+    mode: 'replace'
+  }
+}
+
 function buildRequestContracts ({ scopeName, schemaInfo, includeDepthLimit, sortableFields }) {
   return {
     post: buildWriteDocumentContract(scopeName, schemaInfo, 'post'),
@@ -560,7 +576,10 @@ function buildRequestContracts ({ scopeName, schemaInfo, includeDepthLimit, sort
       includeDepthLimit,
       sortableFields,
       searchSchemaInstance: schemaInfo.searchSchemaInstance
-    })
+    }),
+    postRelationship: buildRelationshipRouteBodyContract('postRelationship'),
+    patchRelationship: buildRelationshipRouteBodyContract('patchRelationship'),
+    deleteRelationship: buildRelationshipRouteBodyContract('deleteRelationship')
   }
 }
 

--- a/tests/fastify-plugin.test.js
+++ b/tests/fastify-plugin.test.js
@@ -2,6 +2,7 @@ import { describe, it, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { Api } from 'hooked-api'
 import { RestApiPlugin, FastifyPlugin } from '../index.js'
+import { getRequestContracts } from '../plugins/core/lib/querying-writing/request-contracts.js'
 import {
   FakeFastifyApp,
   FakeReply,
@@ -75,6 +76,12 @@ describe('Fastify Plugin', () => {
     const postRelationshipRoute = findFastifyRoute(app, 'POST', '/api/articles/:id/relationships/:relationshipName')
     const patchRelationshipRoute = findFastifyRoute(app, 'PATCH', '/api/articles/:id/relationships/:relationshipName')
     const deleteRelationshipRoute = findFastifyRoute(app, 'DELETE', '/api/articles/:id/relationships/:relationshipName')
+    const relationshipContracts = getRequestContracts({
+      scopeName: 'articles',
+      schemaInfo: api.resources.articles.vars.schemaInfo,
+      includeDepthLimit: api.resources.articles.vars.includeDepthLimit,
+      sortableFields: api.resources.articles.vars.sortableFields
+    })
 
     assert.ok(postRoute?.schema?.body, 'POST route should have a body schema')
     assert.ok(putRoute?.schema?.body, 'PUT route should have a body schema')
@@ -108,6 +115,27 @@ describe('Fastify Plugin', () => {
     assert.equal(postRelationshipRoute.schema.body.properties.data.type, 'array')
     assert.ok(Array.isArray(patchRelationshipRoute.schema.body.properties.data.anyOf))
     assert.equal(deleteRelationshipRoute.schema.body.properties.data.type, 'array')
+    assert.deepEqual(
+      postRelationshipRoute.schema.body,
+      relationshipContracts.postRelationship.schema.toJsonSchema({
+        mode: relationshipContracts.postRelationship.mode,
+        additionalProperties: false
+      })
+    )
+    assert.deepEqual(
+      patchRelationshipRoute.schema.body,
+      relationshipContracts.patchRelationship.schema.toJsonSchema({
+        mode: relationshipContracts.patchRelationship.mode,
+        additionalProperties: false
+      })
+    )
+    assert.deepEqual(
+      deleteRelationshipRoute.schema.body,
+      relationshipContracts.deleteRelationship.schema.toJsonSchema({
+        mode: relationshipContracts.deleteRelationship.mode,
+        additionalProperties: false
+      })
+    )
   })
 
   it('registers the JSON:API content-type parser and rejects unsupported write content types before the route handler', async () => {


### PR DESCRIPTION
## Summary
- move Fastify relationship write body schemas onto the shared request-contract surface
- generate relationship route schemas from getRequestContracts alongside resource write schemas
- cover relationship route schema parity in Fastify tests
- mark the audit plan item complete

## Verification
- node --test tests/fastify-plugin.test.js tests/relationship-endpoints.test.js
- JSON_REST_API_STORAGE=anyapi node --test tests/fastify-plugin.test.js tests/relationship-endpoints.test.js
- npm run lint
- npm test
- npm run test:anyapi
- npm run verify