### PR TITLE
Fix post-commit hook failure semantics

### DIFF
--- a/fixing_plan.md
+++ b/fixing_plan.md
@@ -35,11 +35,11 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
   - [x] Verify Socket.IO deferred relationship broadcasts work, or define a separate relationship notification policy.
   - [x] Add tests with an `afterCommit` hook counter and Socket.IO relationship-write subscription behavior.
 
-- [ ] Decide and fix post-commit hook failure semantics. Requires maintainer approval.
-  - [ ] Split transaction work from post-commit side effects.
-  - [ ] Once `commit()` succeeds, do not call rollback handling.
-  - [ ] Decide whether post-commit hook errors are surfaced distinctly or logged/collected while returning success.
-  - [ ] Add tests proving the row remains committed and the response/error semantics are intentional.
+- [x] Decide and fix post-commit hook failure semantics.
+  - [x] Split transaction work from post-commit side effects.
+  - [x] Once `commit()` succeeds, do not call rollback handling.
+  - [x] Surface post-commit hook errors while preserving already-committed data.
+  - [x] Add tests proving the row remains committed and the response/error semantics are intentional.
 
 ## Medium Priority
 

--- a/plugins/core/rest-api-plugin-methods/common.js
+++ b/plugins/core/rest-api-plugin-methods/common.js
@@ -134,7 +134,7 @@ export async function setupCommonRequest ({ params, context, vars, scopes, scope
  */
 export const handleWriteMethodError = async (error, context, method, scopeName, log, runHooks) => {
   // Rollback transaction if we created it
-  if (context.shouldCommit) {
+  if (context.shouldCommit && !context.transactionCommitted) {
     await context.transaction.rollback()
     await runHooks('afterRollback')
   }
@@ -150,6 +150,16 @@ export const handleWriteMethodError = async (error, context, method, scopeName, 
   })
 
   throw error
+}
+
+export const commitOwnedTransaction = async (context, runHooks) => {
+  if (!context.shouldCommit) {
+    return
+  }
+
+  await context.transaction.commit()
+  context.transactionCommitted = true
+  await runHooks('afterCommit')
 }
 
 /**

--- a/plugins/core/rest-api-plugin-methods/delete-relationship.js
+++ b/plugins/core/rest-api-plugin-methods/delete-relationship.js
@@ -1,5 +1,5 @@
 import { RestApiResourceError, RestApiValidationError, RestApiPayloadError } from '../../../lib/rest-api-errors.js'
-import { findRelationshipDefinition, handleWriteMethodError } from './common.js'
+import { commitOwnedTransaction, findRelationshipDefinition, handleWriteMethodError } from './common.js'
 import {
   normalizeRelationshipIdentifiers,
   requireExistingResourceId
@@ -115,10 +115,7 @@ export default async function deleteRelationshipMethod ({ params, context, vars,
     await runHooks('finish')
     await runHooks('finishDeleteRelationship')
 
-    if (context.shouldCommit) {
-      await context.transaction.commit()
-      await runHooks('afterCommit')
-    }
+    await commitOwnedTransaction(context, runHooks)
 
     // 204 No Content
   } catch (error) {

--- a/plugins/core/rest-api-plugin-methods/delete.js
+++ b/plugins/core/rest-api-plugin-methods/delete.js
@@ -1,5 +1,5 @@
 import { RestApiResourceError } from '../../../lib/rest-api-errors.js'
-import { handleWriteMethodError } from './common.js'
+import { commitOwnedTransaction, handleWriteMethodError } from './common.js'
 import { requireExistingResourceId } from '../lib/querying-writing/resource-id-normalization.js'
 
 /**
@@ -96,11 +96,7 @@ export default async function deleteMethod ({
     await runHooks('finish')
     await runHooks('finishDelete')
 
-    // Commit transaction if we created it
-    if (context.shouldCommit) {
-      await context.transaction.commit()
-      await runHooks('afterCommit')
-    }
+    await commitOwnedTransaction(context, runHooks)
 
     // DELETE typically returns void/undefined (204 No Content)
   } catch (error) {

--- a/plugins/core/rest-api-plugin-methods/patch-relationship.js
+++ b/plugins/core/rest-api-plugin-methods/patch-relationship.js
@@ -1,4 +1,4 @@
-import { handleWriteMethodError } from './common.js'
+import { commitOwnedTransaction, handleWriteMethodError } from './common.js'
 import { requireExistingResourceId } from '../lib/querying-writing/resource-id-normalization.js'
 
 /**
@@ -51,10 +51,7 @@ export default async function patchRelationshipMethod ({ params, context, vars, 
     await runHooks('finish')
     await runHooks('finishPatchRelationship')
 
-    if (context.shouldCommit) {
-      await context.transaction.commit()
-      await runHooks('afterCommit')
-    }
+    await commitOwnedTransaction(context, runHooks)
 
     // 204 No Content
   } catch (error) {

--- a/plugins/core/rest-api-plugin-methods/patch.js
+++ b/plugins/core/rest-api-plugin-methods/patch.js
@@ -14,7 +14,8 @@ import {
   applyFieldSetters,
   validatePivotResource,
   handleRecordReturnAfterWrite,
-  handleWriteMethodError
+  handleWriteMethodError,
+  commitOwnedTransaction
 } from './common.js'
 
 /**
@@ -222,11 +223,7 @@ export default async function patchMethod ({
       log
     })
 
-    // Commit transaction if we created it
-    if (context.shouldCommit) {
-      await context.transaction.commit()
-      await runHooks('afterCommit')
-    }
+    await commitOwnedTransaction(context, runHooks)
 
     return ret
   } catch (error) {

--- a/plugins/core/rest-api-plugin-methods/post-relationship.js
+++ b/plugins/core/rest-api-plugin-methods/post-relationship.js
@@ -1,5 +1,5 @@
 import { RestApiResourceError, RestApiValidationError, RestApiPayloadError } from '../../../lib/rest-api-errors.js'
-import { findRelationshipDefinition, handleWriteMethodError } from './common.js'
+import { commitOwnedTransaction, findRelationshipDefinition, handleWriteMethodError } from './common.js'
 import { createPivotRecords } from '../lib/writing/many-to-many-manipulations.js'
 import {
   normalizeRelationshipIdentifiers,
@@ -108,10 +108,7 @@ export default async function postRelationshipMethod ({ params, context, vars, h
     await runHooks('finish')
     await runHooks('finishPostRelationship')
 
-    if (context.shouldCommit) {
-      await context.transaction.commit()
-      await runHooks('afterCommit')
-    }
+    await commitOwnedTransaction(context, runHooks)
 
     // 204 No Content
   } catch (error) {

--- a/plugins/core/rest-api-plugin-methods/post.js
+++ b/plugins/core/rest-api-plugin-methods/post.js
@@ -9,7 +9,8 @@ import {
   applyFieldSetters,
   validatePivotResource,
   handleRecordReturnAfterWrite,
-  handleWriteMethodError
+  handleWriteMethodError,
+  commitOwnedTransaction
 } from './common.js'
 
 /**
@@ -168,11 +169,7 @@ export default async function postMethod ({
       log
     })
 
-    // Commit transaction if we created it
-    if (context.shouldCommit) {
-      await context.transaction.commit()
-      await runHooks('afterCommit')
-    }
+    await commitOwnedTransaction(context, runHooks)
 
     return ret
   } catch (error) {

--- a/plugins/core/rest-api-plugin-methods/put.js
+++ b/plugins/core/rest-api-plugin-methods/put.js
@@ -15,7 +15,8 @@ import {
   applyFieldSetters,
   validatePivotResource,
   handleRecordReturnAfterWrite,
-  handleWriteMethodError
+  handleWriteMethodError,
+  commitOwnedTransaction
 } from './common.js'
 
 /**
@@ -292,11 +293,7 @@ export default async function putMethod ({
       log
     })
 
-    // Commit transaction if we created it
-    if (context.shouldCommit) {
-      await context.transaction.commit()
-      await runHooks('afterCommit')
-    }
+    await commitOwnedTransaction(context, runHooks)
 
     return ret
   } catch (error) {

--- a/tests/post-commit-hooks.test.js
+++ b/tests/post-commit-hooks.test.js
@@ -1,0 +1,120 @@
+import { describe, it, before, after, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import knexLib from 'knex'
+import {
+  cleanTables,
+  countRecords,
+  createJsonApiDocument,
+  createRelationship,
+  resourceIdentifier
+} from './helpers/test-utils.js'
+import { createBasicApi } from './fixtures/api-configs.js'
+
+const knex = knexLib({
+  client: 'better-sqlite3',
+  connection: {
+    filename: ':memory:'
+  },
+  useNullAsDefault: true
+})
+
+let api
+let afterCommitFailureMethod = null
+const rollbackEvents = []
+
+describe('Post-commit hook failure semantics', () => {
+  before(async () => {
+    api = await createBasicApi(knex, {
+      apiName: 'post-commit-hook-test',
+      tablePrefix: 'post_commit'
+    })
+
+    await api.customize({
+      hooks: {
+        afterCommit: {
+          functionName: 'post-commit-failure-test',
+          handler: async ({ context }) => {
+            if (context.method === afterCommitFailureMethod) {
+              throw new Error(`afterCommit failed for ${context.method}`)
+            }
+          }
+        },
+        afterRollback: {
+          functionName: 'post-commit-rollback-tracker',
+          handler: async ({ context }) => {
+            rollbackEvents.push(context.method)
+          }
+        }
+      }
+    })
+  })
+
+  after(async () => {
+    await knex.destroy()
+  })
+
+  beforeEach(async () => {
+    afterCommitFailureMethod = null
+    rollbackEvents.length = 0
+
+    await cleanTables(knex, [
+      'post_commit_countries',
+      'post_commit_publishers',
+      'post_commit_authors',
+      'post_commit_books',
+      'post_commit_book_authors'
+    ])
+  })
+
+  it('surfaces afterCommit errors without rolling back committed resource writes', async () => {
+    afterCommitFailureMethod = 'post'
+
+    await assert.rejects(
+      api.resources.countries.post({
+        inputRecord: createJsonApiDocument('countries', {
+          name: 'Committed Country',
+          code: 'CC'
+        }),
+        simplified: false
+      }),
+      /afterCommit failed for post/
+    )
+
+    assert.equal(await countRecords(knex, 'post_commit_countries'), 1)
+    assert.deepEqual(rollbackEvents, [])
+  })
+
+  it('surfaces afterCommit errors without rolling back committed relationship writes', async () => {
+    const country = await api.resources.countries.post({
+      inputRecord: createJsonApiDocument('countries', { name: 'USA', code: 'US' }),
+      simplified: false
+    })
+    const book = await api.resources.books.post({
+      inputRecord: createJsonApiDocument(
+        'books',
+        { title: 'Committed Book' },
+        { country: createRelationship(resourceIdentifier('countries', country.data.id)) }
+      ),
+      simplified: false
+    })
+    const author = await api.resources.authors.post({
+      inputRecord: createJsonApiDocument('authors', { name: 'Committed Author' }),
+      simplified: false
+    })
+
+    rollbackEvents.length = 0
+    afterCommitFailureMethod = 'postRelationship'
+
+    await assert.rejects(
+      api.resources.books.postRelationship({
+        id: book.data.id,
+        relationshipName: 'authors',
+        relationshipData: [resourceIdentifier('authors', author.data.id)]
+      }),
+      /afterCommit failed for postRelationship/
+    )
+
+    assert.equal(await countRecords(knex, 'post_commit_book_authors'), 1)
+    assert.deepEqual(rollbackEvents, [])
+  })
+})


### PR DESCRIPTION
## Summary
- centralize owned write transaction finalization in one helper
- mark transactions committed before running afterCommit hooks
- skip rollback and afterRollback once commit has succeeded, while still surfacing afterCommit errors
- add regression coverage for resource and relationship writes in both storage modes
- mark the fixing plan item complete

## Verification
- node --test tests/post-commit-hooks.test.js
- JSON_REST_API_STORAGE=anyapi node --test tests/post-commit-hooks.test.js
- node --test tests/post-commit-hooks.test.js tests/relationship-endpoints.test.js tests/socketio.test.js
- JSON_REST_API_STORAGE=anyapi node --test tests/post-commit-hooks.test.js tests/relationship-endpoints.test.js tests/socketio.test.js
- npm run lint
- npm test
- npm run test:anyapi
- npm run verify