### PR TITLE
Harden URL prefix generation

### DIFF
--- a/docs/GUIDE/GUIDE_1_Initial_Setup.md
+++ b/docs/GUIDE/GUIDE_1_Initial_Setup.md
@@ -242,7 +242,7 @@ console.log('Refetched Country:', inspect(countryUsRefetched));
 // }
 ```
 
-(Note that the full JSON:API record includes links to resources, which are automatically generated based on the request headers.)
+(Note that the full JSON:API record includes links to resources, which are generated from explicit URL configuration such as the connector `mountPath` or `publicBaseUrl`.)
 
 As you can see, when `simplified: false` is used:
 

--- a/docs/GUIDE/GUIDE_2_1_The_Starting_Point.md
+++ b/docs/GUIDE/GUIDE_2_1_The_Starting_Point.md
@@ -23,9 +23,9 @@ const knex = knexLib({
 const api = new Api({ name: 'book-catalog-api' });
 
 // Install plugins
-await api.use(RestApiPlugin); // URLs auto-detected from request headers
+await api.use(RestApiPlugin);
 await api.use(RestApiKnexPlugin, { knex });
-await api.use(ExpressPlugin, {  mountPath: '/api' }); // Added: Express Plugin
+await api.use(ExpressPlugin, { mountPath: '/api' }); // Links are generated under /api
 
 /// *** ...programmatic calls here... ***
 

--- a/docs/GUIDE/GUIDE_X_URL_Management.md
+++ b/docs/GUIDE/GUIDE_X_URL_Management.md
@@ -2,316 +2,155 @@
 
 ## Overview
 
-The JSON REST API automatically generates appropriate URLs for all resources in JSON:API responses. URLs are calculated **per-request** based on the incoming request headers, ensuring correct URLs in all deployment scenarios without configuration.
+JSON REST API generates JSON:API links and `Location` headers from explicit library configuration. By default, generated URLs are relative to the configured transport `mountPath`.
 
-## How It Works
+Request headers such as `Host`, `X-Forwarded-Host`, and `X-Forwarded-Proto` are not trusted for URL generation. This keeps links from reflecting attacker-controlled request headers.
 
-### Automatic URL Detection
+## Default Relative Links
 
-URLs in responses (links, hrefs) are automatically generated based on:
-
-1. **Protocol**: Detected from `X-Forwarded-Proto` header or request protocol
-2. **Host**: Detected from `X-Forwarded-Host` or `Host` header  
-3. **Mount Path**: Where your API routes are mounted (e.g., `/api`)
+For a standard Express or Fastify setup:
 
 ```javascript
-// Example: Simple setup - no URL configuration needed!
 await api.use(RestApiPlugin);
 await api.use(RestApiKnexPlugin, { knex });
 await api.use(ExpressPlugin, { mountPath: '/api' });
 ```
 
-### Different Deployment Scenarios
+Generated links use the mount path:
 
-#### Local Development
-```
-Request: GET http://localhost:3000/api/books
-Response links: http://localhost:3000/api/books/1
-```
-
-#### Production with Domain
-```
-Request: GET https://api.example.com/api/books
-Response links: https://api.example.com/api/books/1
-```
-
-#### Behind Reverse Proxy (Nginx/Apache)
-```nginx
-# Nginx configuration
-proxy_set_header X-Forwarded-Proto $scheme;
-proxy_set_header X-Forwarded-Host $host;
-proxy_pass http://backend:3000;
-```
-
-```
-Request headers:
-  X-Forwarded-Proto: https
-  X-Forwarded-Host: api.example.com
-Response links: https://api.example.com/api/books/1
-```
-
-#### Multi-Tenant SaaS
-Each tenant gets their own domain in responses automatically:
-```
-Tenant A request: GET https://customer-a.api.com/api/books
-Response links: https://customer-a.api.com/api/books/1
-
-Tenant B request: GET https://customer-b.api.com/api/books  
-Response links: https://customer-b.api.com/api/books/1
-```
-
-## Advanced: Custom URL Override
-
-For complex deployments (API gateways, CDNs, etc.), you can override URL generation using hooks.
-
-### Recommended Method: API Hooks (Best Practice)
-
-Define a hook when creating your API to handle URL overrides:
-
-```javascript
-const api = new Api({ 
-  name: 'my-api',
-  
-  // Define hooks at API creation time
-  hooks: {
-    'transport:request': [
-      async (payload) => {
-        const { context, req } = payload;
-        
-        // Example: Override based on custom header
-        if (req?.headers?.['x-public-url']) {
-          context.urlPrefixOverride = req.headers['x-public-url'];
-        }
-        
-        // Example: API versioning
-        if (req?.headers?.['x-api-version'] === 'v2') {
-          context.urlPrefixOverride = 'https://api.example.com/v2';
-        }
-        
-        // Example: Multi-tenant based on host
-        const host = req?.hostname;
-        if (host?.includes('tenant-a')) {
-          context.urlPrefixOverride = 'https://tenant-a.api.com/api';
-        }
-        
-        // Example: Environment-based override
-        if (process.env.PUBLIC_API_URL) {
-          context.urlPrefixOverride = process.env.PUBLIC_API_URL;
-        }
-        
-        return payload;
-      }
-    ]
-  }
-});
-
-// Then use plugins normally
-await api.use(RestApiPlugin);
-await api.use(RestApiKnexPlugin, { knex });
-await api.use(ExpressPlugin, { mountPath: '/api' });
-```
-
-### Alternative Method: Express Middleware
-
-If you cannot use hooks, you can use Express middleware before mounting the API:
-
-```javascript
-app.use((req, res, next) => {
-  // Set urlPrefixOverride on the request
-  if (req.headers['x-public-url']) {
-    req.urlPrefixOverride = req.headers['x-public-url'];
-  }
-  next();
-});
-
-// Then mount your API
-app.use(api.http.express.router);
-```
-
-### Common Use Cases for Override
-
-1. **API Gateway with Path Rewriting**
-   ```javascript
-   hooks: {
-     'transport:request': [async (payload) => {
-       if (payload.req?.headers?.['x-forwarded-prefix'] === '/v2') {
-         payload.context.urlPrefixOverride = 'https://api.company.com/v2';
-       }
-       return payload;
-     }]
-   }
-   ```
-
-2. **CDN with Different Public URL**
-   ```javascript
-   hooks: {
-     'transport:request': [async (payload) => {
-       if (payload.req?.headers?.['x-cdn-host']) {
-         payload.context.urlPrefixOverride = `https://${payload.req.headers['x-cdn-host']}/api`;
-       }
-       return payload;
-     }]
-   }
-   ```
-
-3. **Multi-Tenant SaaS**
-   ```javascript
-   hooks: {
-     'transport:request': [async (payload) => {
-       const { context, req } = payload;
-       const tenant = req?.hostname?.split('.')[0];
-       if (tenant && tenant !== 'api') {
-         context.urlPrefixOverride = `https://${tenant}.api.com/api`;
-       }
-       return payload;
-     }]
-   }
-   ```
-
-4. **Environment-Based URLs**
-   ```javascript
-   hooks: {
-     'transport:request': [async (payload) => {
-       // Force production URLs in staging for testing
-       if (process.env.NODE_ENV === 'staging' && process.env.PRODUCTION_URL) {
-         payload.context.urlPrefixOverride = process.env.PRODUCTION_URL;
-       }
-       return payload;
-     }]
-   }
-   ```
-
-## What You DON'T Need to Configure
-
-❌ **No need for:**
-- Static URL configuration
-- Per-environment URL settings
-- Manual protocol detection
-- Proxy configuration in the API
-
-The system automatically handles:
-- HTTP vs HTTPS detection
-- Domain detection from headers
-- Proxy headers (`X-Forwarded-*`)
-- Port numbers
-- Mount paths
-
-## URL Generation Examples
-
-### Resource URLs
-```javascript
-// Generated in responses as:
+```json
 {
-  "type": "books",
-  "id": "123",
-  "attributes": { ... },
-  "links": {
-    "self": "https://api.example.com/api/books/123"  // Automatically generated
-  }
-}
-```
-
-### Relationship URLs
-```javascript
-{
-  "relationships": {
-    "author": {
-      "links": {
-        "self": "https://api.example.com/api/books/123/relationships/author",
-        "related": "https://api.example.com/api/books/123/author"
-      }
+  "data": {
+    "type": "books",
+    "id": "123",
+    "links": {
+      "self": "/api/books/123"
     }
   }
 }
 ```
 
-### Pagination URLs
+This is the recommended default for most deployments. Browsers and HTTP clients resolve the relative links against the origin they already used to call the API.
+
+## Absolute Public Links
+
+When clients require absolute public URLs, configure the connector with `publicBaseUrl`. The value is the complete public URL prefix for generated API links, including any public path prefix such as `/api`.
+
 ```javascript
+await api.use(ExpressPlugin, {
+  mountPath: '/api',
+  publicBaseUrl: 'https://api.example.com/api'
+});
+```
+
+Fastify uses the same option:
+
+```javascript
+await api.use(FastifyPlugin, {
+  app,
+  mountPath: '/api',
+  publicBaseUrl: 'https://api.example.com/api'
+});
+```
+
+Generated links then use the configured public base URL:
+
+```json
 {
   "links": {
-    "self": "https://api.example.com/api/books?page[number]=2",
-    "first": "https://api.example.com/api/books?page[number]=1",
-    "prev": "https://api.example.com/api/books?page[number]=1",
-    "next": "https://api.example.com/api/books?page[number]=3",
-    "last": "https://api.example.com/api/books?page[number]=10"
+    "self": "https://api.example.com/api/books/123"
   }
 }
 ```
 
-## Benefits of Per-Request URL Generation
+Trailing slashes on `publicBaseUrl` are normalized before links are built.
 
-1. **Zero Configuration**: Works correctly out of the box
-2. **Multi-Domain Safe**: Each request gets appropriate URLs
-3. **Proxy Friendly**: Automatically handles reverse proxies
-4. **Flexible**: Override when needed for complex scenarios
-5. **Stateless**: No global state that can be contaminated
+## Per-Request Overrides
+
+For multi-tenant deployments or API gateways with request-specific public URLs, set `context.urlPrefixOverride` in a `transport:request` hook. Only set this from trusted configuration or validated request metadata.
+
+```javascript
+await api.customize({
+  hooks: {
+    'transport:request': {
+      functionName: 'tenant-url-prefix',
+      handler: async ({ context }) => {
+        const tenantId = context.auth?.tenantId;
+        const tenantPublicUrls = {
+          tenant_a: 'https://tenant-a.example.com/api',
+          tenant_b: 'https://tenant-b.example.com/api'
+        };
+
+        if (tenantPublicUrls[tenantId]) {
+          context.urlPrefixOverride = tenantPublicUrls[tenantId];
+        }
+      }
+    }
+  }
+});
+```
+
+Express middleware can also set `req.urlPrefixOverride` before the API router runs:
+
+```javascript
+const allowedPublicUrls = new Set([
+  'https://api.example.com/api',
+  'https://partner.example.com/api'
+]);
+
+app.use((req, res, next) => {
+  const requestedPublicUrl = req.get('x-public-url');
+  if (allowedPublicUrls.has(requestedPublicUrl)) {
+    req.urlPrefixOverride = requestedPublicUrl;
+  }
+  next();
+});
+
+api.http.express.mount(app);
+```
+
+Do not copy arbitrary `Host`, `X-Forwarded-Host`, or custom public URL headers into `urlPrefixOverride`. If a reverse proxy supplies public URL metadata, validate it against trusted configuration first.
+
+## Priority Order
+
+URL prefix resolution uses this order:
+
+1. `context.urlPrefixOverride`
+2. Connector `publicBaseUrl`
+3. Connector `mountPath`
+4. Empty string
+
+The same helper is used for resource links, relationship links, pagination links, and connector `Location` headers.
+
+## Reverse Proxies
+
+A reverse proxy should still forward requests to the Node.js application normally, but URL generation does not require forwarding public host headers.
+
+Use explicit configuration for public links:
+
+```javascript
+await api.use(ExpressPlugin, {
+  mountPath: '/api',
+  publicBaseUrl: process.env.PUBLIC_API_URL
+});
+```
+
+Set `PUBLIC_API_URL` to the externally visible API prefix, for example `https://api.example.com/api`.
 
 ## Troubleshooting
 
-### URLs are showing localhost in production
-- Ensure your reverse proxy is setting `X-Forwarded-Host` and `X-Forwarded-Proto` headers
-- Check that these headers are being passed through to your application
+### Links are relative
 
-### Need different URLs for different environments
-- Use the `urlPrefixOverride` pattern with environment variables
-- Set `PUBLIC_API_URL` environment variable appropriately
+This is the default behavior. Configure `publicBaseUrl` if your clients require absolute URLs.
 
-### API Gateway stripping paths
-- Use middleware to set `req.urlPrefixOverride` with the full public path
-- Include any path prefixes that the gateway strips
+### Links are missing a public path prefix
 
-## Complete Working Example
-
-Here's a full example showing URL override with hooks:
+Include the public path prefix in `publicBaseUrl`.
 
 ```javascript
-import { Api } from 'hooked-api';
-import { RestApiPlugin, RestApiKnexPlugin, ExpressPlugin } from 'json-rest-api';
-import express from 'express';
-
-// Create API with URL override hook
-const api = new Api({ 
-  name: 'my-api',
-  hooks: {
-    'transport:request': [
-      async (payload) => {
-        const { context, req } = payload;
-        
-        // Check for custom public URL header
-        if (req?.headers?.['x-public-url']) {
-          context.urlPrefixOverride = req.headers['x-public-url'];
-        }
-        
-        return payload;
-      }
-    ]
-  }
-});
-
-// Install plugins
-await api.use(RestApiPlugin);
-await api.use(RestApiKnexPlugin, { knex });
-await api.use(ExpressPlugin, { mountPath: '/api' });
-
-// Define resources...
-await api.addResource('books', { /* schema */ });
-
-// Create Express app
-const app = express();
-app.use(api.http.express.router);
-app.listen(3000);
+publicBaseUrl: 'https://api.example.com/v2'
 ```
 
-Now your API automatically handles:
-- `curl http://localhost:3000/api/books` → URLs: `http://localhost:3000/api/books/1`
-- `curl -H "X-Public-URL: https://cdn.example.com/api" http://localhost:3000/api/books` → URLs: `https://cdn.example.com/api/books/1`
+### Multi-tenant links need different hosts
 
-## Summary
-
-The JSON REST API's URL management system provides:
-- **Automatic detection** for 99% of use cases
-- **Hook-based override** for complex deployments
-- **Per-request isolation** preventing cross-domain issues
-- **No configuration** required for standard deployments
-
-Just set your `mountPath` in the Express plugin and optionally define hooks for custom scenarios!
+Use `context.urlPrefixOverride` from trusted tenant or auth state. Avoid deriving tenant URLs directly from untrusted request host headers.

--- a/fixing_plan.md
+++ b/fixing_plan.md
@@ -60,11 +60,11 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
   - [x] Replace `startsWith(resolvedDir)` containment with `path.relative(resolvedDir, resolvedPath)`.
   - [x] Add tests for sibling-prefix traversal such as `../uploads_evil/pwn`.
 
-- [ ] Fix untrusted proxy URL generation. Requires maintainer approval.
-  - [ ] Stop trusting `Host` and `X-Forwarded-*` by default for absolute links.
-  - [ ] Prefer relative links unless `urlPrefixOverride` or an explicit public base URL is configured.
-  - [ ] If forwarded headers remain supported, gate them behind `trustProxy` and allowed host/proto validation.
-  - [ ] Add Express and Fastify tests with hostile `Host` and `X-Forwarded-Host` headers.
+- [x] Fix untrusted proxy URL generation. Requires maintainer approval.
+  - [x] Stop trusting `Host` and `X-Forwarded-*` by default for absolute links.
+  - [x] Prefer relative links unless `urlPrefixOverride` or an explicit public base URL is configured.
+  - [x] If forwarded headers remain supported, gate them behind `trustProxy` and allowed host/proto validation. Resolved by not supporting forwarded headers for URL generation.
+  - [x] Add Express and Fastify tests with hostile `Host` and `X-Forwarded-Host` headers.
 
 - [ ] Fix `S3Storage` non-mock behavior. Dependency/public behavior choice requires maintainer approval.
   - [ ] Smallest safe fix: throw a clear "real S3 storage is not implemented" error when `mockMode: false`.

--- a/plugins/core/connectors/express-plugin.js
+++ b/plugins/core/connectors/express-plugin.js
@@ -66,6 +66,7 @@ export const ExpressPlugin = {
     // Get mountPath from options (this is now a transport concern)
     const mountPath = expressOptions.mountPath || ''
     const basePath = mountPath // Keep basePath for internal use
+    const publicBaseUrl = expressOptions.publicBaseUrl || ''
     const strictContentType = expressOptions.strictContentType !== false
     const requestSizeLimit = expressOptions.requestSizeLimit || '1mb'
 
@@ -73,7 +74,8 @@ export const ExpressPlugin = {
     vars.transport = {
       type: 'express',
       matchAll: '*', // Express wildcard pattern for matching all routes
-      mountPath // Transport-specific mount path
+      mountPath, // Transport-specific mount path
+      publicBaseUrl
     }
 
     // Register file detector if enabled
@@ -142,6 +144,7 @@ export const ExpressPlugin = {
         reply: res,
         source: 'express',
         mountPath: basePath,
+        publicBaseUrl,
         requestData,
         createContext,
         urlPrefixOverride: req.urlPrefixOverride
@@ -240,6 +243,7 @@ export const ExpressPlugin = {
                 reply: res,
                 source: 'express',
                 mountPath: basePath,
+                publicBaseUrl,
                 requestData,
                 createContext,
                 urlPrefixOverride: req.urlPrefixOverride
@@ -262,6 +266,7 @@ export const ExpressPlugin = {
               routeMeta,
               helpers,
               mountPath: basePath,
+              publicBaseUrl,
               runHooks
             })
             res.set(outcome.headers)

--- a/plugins/core/connectors/fastify-plugin.js
+++ b/plugins/core/connectors/fastify-plugin.js
@@ -70,12 +70,14 @@ export const FastifyPlugin = {
     api.http.fastify = { app }
 
     const mountPath = fastifyOptions.mountPath || ''
+    const publicBaseUrl = fastifyOptions.publicBaseUrl || ''
     const strictContentType = fastifyOptions.strictContentType !== false
 
     vars.transport = {
       type: 'fastify',
       matchAll: '*',
-      mountPath
+      mountPath,
+      publicBaseUrl
     }
 
     registerVendorJsonParser(app)
@@ -140,6 +142,7 @@ export const FastifyPlugin = {
             reply,
             source: 'fastify',
             mountPath,
+            publicBaseUrl,
             requestData,
             createContext
           })
@@ -174,6 +177,7 @@ export const FastifyPlugin = {
             routeMeta,
             helpers,
             mountPath,
+            publicBaseUrl,
             runHooks
           })
 

--- a/plugins/core/connectors/lib/connector-core.js
+++ b/plugins/core/connectors/lib/connector-core.js
@@ -43,6 +43,7 @@ export function createConnectorContext ({
   reply,
   source,
   mountPath = '',
+  publicBaseUrl = '',
   requestData,
   createContext,
   urlPrefixOverride
@@ -55,8 +56,7 @@ export function createConnectorContext ({
 
   context.urlPrefix = getUrlPrefix(
     context,
-    { vars: { transport: { mountPath } } },
-    request
+    { vars: { transport: { mountPath, publicBaseUrl } } }
   )
 
   const transportData = buildTransportData(requestData)
@@ -113,7 +113,8 @@ export function getConnectorLocationHeader ({
   context,
   routeMeta,
   helpers,
-  mountPath = ''
+  mountPath = '',
+  publicBaseUrl = ''
 }) {
   if (String(method || '').toUpperCase() !== 'POST') return null
   if (!context?.id || !routeMeta?.scopeName || !helpers?.getLocation) return null
@@ -123,7 +124,9 @@ export function getConnectorLocationHeader ({
     id: context.id
   })
 
-  const baseUrl = context.urlPrefix || mountPath
+  const baseUrl = getUrlPrefix(context, {
+    vars: { transport: { mountPath, publicBaseUrl } }
+  })
   return `${baseUrl}${location}`
 }
 
@@ -139,6 +142,7 @@ export async function executeConnectorRoute ({
   routeMeta,
   helpers,
   mountPath = '',
+  publicBaseUrl = '',
   runHooks
 }) {
   const result = await handler({
@@ -150,6 +154,14 @@ export async function executeConnectorRoute ({
   })
 
   const status = determineResponseStatus(method, result)
+  const location = getConnectorLocationHeader({
+    method,
+    context,
+    routeMeta,
+    helpers,
+    mountPath,
+    publicBaseUrl
+  })
   const transportHeaders = await applyTransportResponseLifecycle({
     context,
     transportData,
@@ -165,13 +177,7 @@ export async function executeConnectorRoute ({
       ...(result?.headers || {}),
       ...transportHeaders
     },
-    location: getConnectorLocationHeader({
-      method,
-      context,
-      routeMeta,
-      helpers,
-      mountPath
-    }),
+    location,
     result
   }
 }

--- a/plugins/core/lib/querying/url-helpers.js
+++ b/plugins/core/lib/querying/url-helpers.js
@@ -11,13 +11,12 @@
  * Priority order:
  * 1. context.urlPrefixOverride - Explicit override (from hooks or middleware)
  * 2. context.urlPrefix - Pre-calculated URL prefix
- * 3. Calculate from request if provided
- * 4. scope.vars.transport?.mountPath - Fallback to mount path
+ * 3. scope.vars.transport?.publicBaseUrl - Explicit public URL prefix
+ * 4. scope.vars.transport?.mountPath - Fallback to relative mount path
  * 5. '' - Empty string as final fallback
  *
  * @param {Object} context - Request context (may have urlPrefixOverride or urlPrefix)
  * @param {Object} scope - Scope/resource object with transport vars
- * @param {Object} req - Optional Express request object for auto-calculation
  * @returns {string} The final URL prefix to use
  *
  * @example
@@ -25,10 +24,10 @@
  * const urlPrefix = getUrlPrefix(context, scope);
  *
  * @example
- * // With request object for auto-calculation
- * const urlPrefix = getUrlPrefix({}, api, req);
+ * // With explicit public base URL
+ * const urlPrefix = getUrlPrefix({}, { vars: { transport: { publicBaseUrl: 'https://api.example.com/api' } } });
  */
-export function getUrlPrefix (context, scope, req = null) {
+export function getUrlPrefix (context, scope) {
   // Priority 1: Explicit override
   if (context?.urlPrefixOverride) {
     return context.urlPrefixOverride
@@ -39,21 +38,10 @@ export function getUrlPrefix (context, scope, req = null) {
     return context.urlPrefix
   }
 
-  // Priority 3: Calculate from request if provided
-  if (req) {
-    const protocol = req.get?.('x-forwarded-proto') ||
-      req.headers?.['x-forwarded-proto'] ||
-      req.protocol ||
-      'http'
-    const host = req.get?.('x-forwarded-host') ||
-      req.headers?.['x-forwarded-host'] ||
-      req.get?.('host') ||
-      req.headers?.host
-    const mountPath = scope?.vars?.transport?.mountPath || ''
-
-    if (host) {
-      return `${protocol}://${host}${mountPath}`
-    }
+  // Priority 3: Explicit public URL prefix configured by the transport
+  const publicBaseUrl = scope?.vars?.transport?.publicBaseUrl
+  if (publicBaseUrl) {
+    return String(publicBaseUrl).replace(/\/+$/, '')
   }
 
   // Priority 4: Fallback to mount path

--- a/tests/http-connectors-parity.test.js
+++ b/tests/http-connectors-parity.test.js
@@ -25,13 +25,21 @@ const knex = knexLib({
   useNullAsDefault: true
 })
 
-async function createConnectorParityApi () {
+async function createConnectorParityApi ({
+  name = 'connector-parity-test-api',
+  tableName = 'connector_parity_countries',
+  publicBaseUrl = ''
+} = {}) {
   const expressApp = express()
   const fastifyApp = new FakeFastifyApp()
   const api = new Api({
-    name: 'connector-parity-test-api',
+    name,
     log: { level: process.env.LOG_LEVEL || 'silent' }
   })
+  const transportOptions = {
+    mountPath: '/api',
+    ...(publicBaseUrl ? { publicBaseUrl } : {})
+  }
 
   await api.use(RestApiPlugin, {
     simplifiedApi: false,
@@ -50,10 +58,10 @@ async function createConnectorParityApi () {
   })
 
   await api.use(RestApiKnexPlugin, { knex })
-  await api.use(ExpressPlugin, { mountPath: '/api' })
+  await api.use(ExpressPlugin, transportOptions)
   await api.use(FastifyPlugin, {
     app: fastifyApp,
-    mountPath: '/api'
+    ...transportOptions
   })
 
   await api.customize({
@@ -61,6 +69,10 @@ async function createConnectorParityApi () {
       'transport:request': {
         functionName: 'connector-parity-rejector',
         handler: async ({ context }) => {
+          if (context.transport?.request?.headers?.['x-use-public-url-override'] === 'yes') {
+            context.urlPrefixOverride = 'https://trusted.example/api'
+          }
+
           if (context.transport?.request?.headers?.['x-block-request'] === 'yes') {
             context.reject(401, 'Blocked by connector parity hook', {
               title: 'Unauthorized'
@@ -83,7 +95,7 @@ async function createConnectorParityApi () {
       name: { type: 'string', required: true, max: 100 },
       code: { type: 'string', max: 2 }
     },
-    tableName: 'connector_parity_countries'
+    tableName
   })
 
   await api.resources.countries.createKnexTable()
@@ -99,6 +111,12 @@ function assertLocationSuffix (location, resourceId) {
       location.endsWith(`/countries/${resourceId}`),
     `Unexpected Location header: ${location}`
   )
+}
+
+function assertResourceLinksUsePrefix (body, expectedPrefix) {
+  const resourceId = body.data.id
+  assert.equal(body.data.links.self, `${expectedPrefix}/countries/${resourceId}`)
+  assert.equal(body.links.self, `${expectedPrefix}/countries/${resourceId}`)
 }
 
 describe('HTTP Connector Parity', () => {
@@ -157,6 +175,148 @@ describe('HTTP Connector Parity', () => {
 
     assertLocationSuffix(expressResponse.headers.location, expressResponse.body.data.id)
     assertLocationSuffix(fastifyReply.headers.Location, fastifyReply.payload.data.id)
+  })
+
+  it('does not build response URLs from untrusted proxy headers', async () => {
+    const expressDoc = createJsonApiDocument('countries', {
+      name: 'Express Hostile Header Country',
+      code: 'EH'
+    })
+    const fastifyDoc = createJsonApiDocument('countries', {
+      name: 'Fastify Hostile Header Country',
+      code: 'FH'
+    })
+
+    const expressResponse = await request(expressApp)
+      .post('/api/countries')
+      .set('Content-Type', 'application/vnd.api+json')
+      .set('Accept', 'application/vnd.api+json')
+      .set('Host', 'attacker.example')
+      .set('X-Forwarded-Host', 'proxy-attacker.example')
+      .set('X-Forwarded-Proto', 'https')
+      .send(expressDoc)
+
+    const { reply: fastifyReply } = await invokeFastifyRoute(fastifyApp, {
+      method: 'POST',
+      routeUrl: '/api/countries',
+      requestUrl: '/api/countries',
+      headers: {
+        'content-type': 'application/vnd.api+json',
+        accept: 'application/vnd.api+json',
+        host: 'attacker.example',
+        'x-forwarded-host': 'proxy-attacker.example',
+        'x-forwarded-proto': 'https'
+      },
+      body: fastifyDoc
+    })
+
+    assert.equal(expressResponse.status, 201)
+    assert.equal(fastifyReply.statusCode, 201)
+    assert.equal(
+      expressResponse.headers.location,
+      `/api/countries/${expressResponse.body.data.id}`
+    )
+    assert.equal(
+      fastifyReply.headers.Location,
+      `/api/countries/${fastifyReply.payload.data.id}`
+    )
+    assertResourceLinksUsePrefix(expressResponse.body, '/api')
+    assertResourceLinksUsePrefix(fastifyReply.payload, '/api')
+  })
+
+  it('uses explicit publicBaseUrl when a connector is configured with one', async () => {
+    const {
+      expressApp: publicExpressApp,
+      fastifyApp: publicFastifyApp
+    } = await createConnectorParityApi({
+      name: 'connector-parity-public-url-test-api',
+      tableName: 'connector_parity_public_countries',
+      publicBaseUrl: 'https://public.example/api/'
+    })
+
+    const expressDoc = createJsonApiDocument('countries', {
+      name: 'Express Public Country',
+      code: 'EP'
+    })
+    const fastifyDoc = createJsonApiDocument('countries', {
+      name: 'Fastify Public Country',
+      code: 'FP'
+    })
+
+    const expressResponse = await request(publicExpressApp)
+      .post('/api/countries')
+      .set('Content-Type', 'application/vnd.api+json')
+      .set('Accept', 'application/vnd.api+json')
+      .send(expressDoc)
+
+    const { reply: fastifyReply } = await invokeFastifyRoute(publicFastifyApp, {
+      method: 'POST',
+      routeUrl: '/api/countries',
+      requestUrl: '/api/countries',
+      headers: {
+        'content-type': 'application/vnd.api+json',
+        accept: 'application/vnd.api+json'
+      },
+      body: fastifyDoc
+    })
+
+    assert.equal(expressResponse.status, 201)
+    assert.equal(fastifyReply.statusCode, 201)
+    assert.equal(
+      expressResponse.headers.location,
+      `https://public.example/api/countries/${expressResponse.body.data.id}`
+    )
+    assert.equal(
+      fastifyReply.headers.Location,
+      `https://public.example/api/countries/${fastifyReply.payload.data.id}`
+    )
+    assertResourceLinksUsePrefix(expressResponse.body, 'https://public.example/api')
+    assertResourceLinksUsePrefix(fastifyReply.payload, 'https://public.example/api')
+
+    await cleanTables(knex, ['connector_parity_public_countries'])
+  })
+
+  it('honors urlPrefixOverride set during transport request hooks', async () => {
+    const expressDoc = createJsonApiDocument('countries', {
+      name: 'Express Override Country',
+      code: 'EO'
+    })
+    const fastifyDoc = createJsonApiDocument('countries', {
+      name: 'Fastify Override Country',
+      code: 'FO'
+    })
+
+    const expressResponse = await request(expressApp)
+      .post('/api/countries')
+      .set('Content-Type', 'application/vnd.api+json')
+      .set('Accept', 'application/vnd.api+json')
+      .set('x-use-public-url-override', 'yes')
+      .send(expressDoc)
+
+    const { reply: fastifyReply } = await invokeFastifyRoute(fastifyApp, {
+      method: 'POST',
+      routeUrl: '/api/countries',
+      requestUrl: '/api/countries',
+      headers: {
+        'content-type': 'application/vnd.api+json',
+        accept: 'application/vnd.api+json',
+        'x-use-public-url-override': 'yes'
+      },
+      body: fastifyDoc
+    })
+
+    assert.equal(expressResponse.status, 201)
+    assert.equal(fastifyReply.statusCode, 201)
+    assert.equal(
+      expressResponse.headers.location,
+      `https://trusted.example/api/countries/${expressResponse.body.data.id}`
+    )
+    assert.equal(
+      fastifyReply.headers.Location,
+      `https://trusted.example/api/countries/${fastifyReply.payload.data.id}`
+    )
+    assertResourceLinksUsePrefix(expressResponse.body, 'https://trusted.example/api')
+    assertResourceLinksUsePrefix(fastifyReply.payload, 'https://trusted.example/api')
   })
 
   it('rejects unsupported write content types using each connector transport policy', async () => {


### PR DESCRIPTION
## Summary
- stop deriving generated JSON:API links and Location headers from Host and X-Forwarded-* request headers
- add explicit publicBaseUrl connector configuration for Express/Fastify absolute links
- update URL-management docs and connector parity coverage for hostile headers, publicBaseUrl, and request-hook urlPrefixOverride

## Verification
- node --test tests/http-connectors-parity.test.js
- npm run lint
- npm test
- npm run test:anyapi
- npm run verify