### PR TITLE
Harden S3 storage mock mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A powerful REST API plugin for [hooked-api](https://github.com/mobily-enterprise
 * **JSON:API Compliant** - Full support for the JSON:API specification
 * **Relationship Support** - `belongsTo`, `hasMany`, and many-to-many relationships, including polymorphic
 * **Advanced Querying** - Filtering, sorting, pagination, and field selection (sparse fieldsets)
-* **File Uploads** - Built-in support for file handling with multiple storage adapters (local, S3)
+* **File Uploads** - Built-in support for file handling with local storage and a mock S3-style demo adapter
 * **Framework Agnostic** - Works with raw Node.js HTTP, Express, and other Node.js frameworks via flexible connectors
 * **Validation** - Schema-based validation with detailed error messages and custom rules
 * **Simplified Mode** - A developer-friendly option to work with plain JavaScript objects instead of verbose JSON:API structure

--- a/docs/GUIDE/GUIDE_X_File_Uploads.md
+++ b/docs/GUIDE/GUIDE_X_File_Uploads.md
@@ -19,7 +19,7 @@ The file handling system consists of three main components:
 
 1. **FileHandlingPlugin** - Orchestrates file detection and processing
 2. **Protocol Detectors** - Parse files from different protocols (HTTP, Express)
-3. **Storage Adapters** - Save files to different backends (local, S3, etc.)
+3. **Storage Adapters** - Save files to local storage or generate mock S3-style URLs for demos
 
 ### How It Works
 
@@ -115,11 +115,11 @@ Storage adapters handle where and how files are saved. The library includes two 
 | **Extension Whitelist** | ✅ Yes | ❌ No |
 | **Duplicate Handling** | ✅ Yes | ✅ Automatic |
 | **Custom Naming** | ✅ Yes | ❌ No |
-| **Best For** | Local file storage | Cloud storage |
+| **Best For** | Local file storage | Tests, examples, S3-style URL demos |
 
-### S3Storage
+### S3Storage (Mock/Demo)
 
-Saves files to Amazon S3 or S3-compatible storage:
+Generates S3-style URLs without uploading files to Amazon S3:
 
 ```javascript
 import { S3Storage } from 'json-rest-api/plugins/storage/s3-storage.js';
@@ -129,7 +129,7 @@ const s3Storage = new S3Storage({
   region: 'us-east-1',                 // AWS region (default: 'us-east-1')
   prefix: 'uploads/',                  // Path prefix in bucket (default: '')
   acl: 'public-read',                  // Access control (default: 'public-read')
-  mockMode: false                      // Use mock mode? (default: true)
+  mockMode: true                       // Only supported mode
 });
 ```
 
@@ -137,7 +137,7 @@ const s3Storage = new S3Storage({
 - Always generates random hash + extension (e.g., `uploads/a7f8d9e2b4c6e1f3.jpg`)
 - Original filenames are never used for security
 
-**Note**: The included S3Storage is a mock implementation for demonstration. For production use, you'll need to implement the actual AWS SDK calls.
+**Note**: The included S3Storage is a mock implementation for demonstration. `mockMode: false` throws a clear error because real S3 uploads are not implemented. For production use, provide your own storage adapter or add an AWS SDK-backed implementation.
 
 ### LocalStorage
 

--- a/docs/GUIDE/index.md
+++ b/docs/GUIDE/index.md
@@ -28,7 +28,7 @@ Welcome to the comprehensive guide for JSON REST API. This guide will walk you t
 ### Additional Topics
 
 - **[File Uploads](GUIDE_X_File_Uploads.md)**  
-  Handle file uploads with multiple backends (file system, S3).
+  Handle file uploads with local storage and a mock S3-style demo adapter.
 
 - **[Bulk Operations](GUIDE_X_Bulk_Operations.md)**  
   Handle multiple records efficiently with bulk create, update, and delete operations.

--- a/fixing_plan.md
+++ b/fixing_plan.md
@@ -66,10 +66,10 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
   - [x] If forwarded headers remain supported, gate them behind `trustProxy` and allowed host/proto validation. Resolved by not supporting forwarded headers for URL generation.
   - [x] Add Express and Fastify tests with hostile `Host` and `X-Forwarded-Host` headers.
 
-- [ ] Fix `S3Storage` non-mock behavior. Dependency/public behavior choice requires maintainer approval.
-  - [ ] Smallest safe fix: throw a clear "real S3 storage is not implemented" error when `mockMode: false`.
-  - [ ] Full fix option: add AWS SDK support and real upload/delete implementation.
-  - [ ] Add tests for mock mode and the chosen non-mock behavior.
+- [x] Fix `S3Storage` non-mock behavior. Dependency/public behavior choice requires maintainer approval.
+  - [x] Smallest safe fix: throw a clear "real S3 storage is not implemented" error when `mockMode: false`.
+  - [x] Reject full AWS SDK support for this pass because it adds dependency, credential, and public behavior scope.
+  - [x] Add tests for mock mode and the chosen non-mock behavior.
 
 ## Low Priority
 
@@ -92,9 +92,9 @@ Checklist-style plan for addressing the audit findings. Items marked as requirin
   - [x] Remove invalid deep imports such as `json-rest-api/plugins/socketio`, or add formal package subpath exports. Subpath exports require maintainer approval.
   - [x] Add a public import smoke test.
 
-- [ ] Align S3 documentation with implementation.
-  - [ ] If real S3 is not implemented, make README and guide text state that the included adapter is mock/demo only.
-  - [ ] If real S3 is implemented, update docs and tests to match the production behavior.
+- [x] Align S3 documentation with implementation.
+  - [x] Since real S3 is not implemented, make README and guide text state that the included adapter is mock/demo only.
+  - [x] Leave production S3 as a future approved dependency/API design rather than documenting unsupported behavior.
 
 - [x] Finish relationship validation contract consolidation.
   - [x] Move relationship-route schemas into the same request-contract surface as resource routes.

--- a/plugins/storage/s3-storage.js
+++ b/plugins/storage/s3-storage.js
@@ -1,18 +1,17 @@
 /**
- * S3 Storage Adapter
+ * S3 Storage Adapter (mock/demo)
  *
- * Stores uploaded files in Amazon S3 or S3-compatible storage.
+ * Generates S3-style URLs without uploading files to Amazon S3.
  *
  * Usage:
  * ```javascript
- * import { S3Storage } from 'jsonrestapi/lib/storage/s3-storage.js';
+ * import { S3Storage } from 'json-rest-api';
  *
  * const storage = new S3Storage({
  *   bucket: 'my-uploads',
  *   region: 'us-east-1',
- *   accessKeyId: process.env.AWS_ACCESS_KEY_ID,
- *   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
- *   prefix: 'uploads/' // optional path prefix
+ *   prefix: 'uploads/',
+ *   mockMode: true
  * });
  *
  * const schema = {
@@ -23,6 +22,12 @@
 
 import crypto from 'crypto'
 import path from 'path'
+
+const REAL_S3_NOT_IMPLEMENTED_MESSAGE = 'S3Storage real S3 mode is not implemented. The included adapter only supports mockMode: true; provide a production storage adapter or add an AWS SDK-backed implementation.'
+
+function createRealS3NotImplementedError () {
+  return new Error(REAL_S3_NOT_IMPLEMENTED_MESSAGE)
+}
 
 export class S3Storage {
   constructor (options = {}) {
@@ -35,19 +40,15 @@ export class S3Storage {
       throw new Error('S3Storage requires a bucket name')
     }
 
-    // Note: In a real implementation, you would initialize the AWS SDK here
-    // For this example, we'll just mock the behavior
     this.mockMode = options.mockMode !== false // Default to mock mode
 
     if (!this.mockMode) {
-      // Real S3 initialization would go here
-      // const { S3Client } = require('@aws-sdk/client-s3');
-      // this.s3 = new S3Client({ region: this.region });
+      throw createRealS3NotImplementedError()
     }
   }
 
   /**
-   * Upload a file to S3
+   * Upload a file to mock S3 storage.
    * @param {Object} file - File object from detector
    * @returns {Promise<string>} URL of the uploaded file
    */
@@ -67,61 +68,26 @@ export class S3Storage {
       return url
     }
 
-    // Real S3 upload would go here
-    /*
-    const { PutObjectCommand } = require('@aws-sdk/client-s3');
-
-    const command = new PutObjectCommand({
-      Bucket: this.bucket,
-      Key: key,
-      Body: file.data,
-      ContentType: file.mimetype,
-      ACL: this.acl,
-      Metadata: {
-        originalName: file.filename
-      }
-    });
-
-    await this.s3.send(command);
-
-    // Return public URL
-    if (this.acl === 'public-read') {
-      return `https://${this.bucket}.s3.${this.region}.amazonaws.com/${key}`;
-    } else {
-      // For private files, you might return a signed URL
-      return await this.getSignedUrl(key);
-    }
-    */
+    throw createRealS3NotImplementedError()
   }
 
   /**
-   * Delete a file from S3
+   * Delete a file from mock S3 storage.
    * @param {string} url - URL returned by upload()
    * @returns {Promise<void>}
    */
   async delete (url) {
-    const urlObj = new URL(url)
-
-    if (this.mockMode) {
-      // Mock mode - just simulate deletion
-      await new Promise(resolve => setTimeout(resolve, 50))
-      return
+    if (!this.mockMode) {
+      throw createRealS3NotImplementedError()
     }
+
+    const urlObj = new URL(url)
 
     if (urlObj.pathname.length === 0) {
       throw new Error('Invalid S3 object URL')
     }
 
-    // Real S3 delete would go here
-    /*
-    const { DeleteObjectCommand } = require('@aws-sdk/client-s3');
-
-    const command = new DeleteObjectCommand({
-      Bucket: this.bucket,
-      Key: key
-    });
-
-    await this.s3.send(command);
-    */
+    // Mock mode - just simulate deletion
+    await new Promise(resolve => setTimeout(resolve, 50))
   }
 }

--- a/tests/s3-storage.test.js
+++ b/tests/s3-storage.test.js
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { S3Storage } from '../index.js'
+
+function createFile (filename = 'photo.png') {
+  return {
+    filename,
+    mimetype: 'image/png',
+    data: Buffer.from('file contents')
+  }
+}
+
+describe('S3Storage', () => {
+  it('requires a bucket name', () => {
+    assert.throws(() => new S3Storage(), /S3Storage requires a bucket name/)
+  })
+
+  it('generates S3-style mock URLs and accepts deleting returned URLs', async () => {
+    const storage = new S3Storage({
+      bucket: 'my-uploads',
+      region: 'ap-southeast-2',
+      prefix: 'uploads/'
+    })
+
+    const url = await storage.upload(createFile())
+
+    assert.match(url, /^https:\/\/my-uploads\.s3\.ap-southeast-2\.amazonaws\.com\/uploads\/[a-f0-9]{32}\.png$/)
+    await assert.doesNotReject(storage.delete(url))
+  })
+
+  it('fails clearly when real S3 mode is requested', () => {
+    assert.throws(
+      () => new S3Storage({ bucket: 'my-uploads', mockMode: false }),
+      /S3Storage real S3 mode is not implemented/
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Fail fast when S3Storage is configured with unsupported real S3 mode
- Add S3Storage tests for bucket validation, mock URLs, and non-mock fail-fast behavior
- Align README, guide docs, and fixing_plan checklist with the mock/demo-only adapter behavior

## Verification
- node --test tests/s3-storage.test.js
- node --test tests/s3-storage.test.js tests/file-handling.test.js tests/local-storage.test.js
- npm run docs
- npm run lint
- npm test
- npm run test:anyapi
- npm run verify