### PR TITLE
Align shared query and relationship contracts

### DIFF
--- a/plugins/core/rest-api-anyapi-knex-plugin.js
+++ b/plugins/core/rest-api-anyapi-knex-plugin.js
@@ -54,6 +54,7 @@ import {
   parseSortEntry
 } from './lib/querying/query-field-sort-helpers.js'
 import { unwrapQueryBuilderState } from './lib/querying/query-builder-utils.js'
+import { serializeJsonApiQuery } from './lib/querying-writing/connectors-query-parser.js'
 
 const DEFAULT_TENANT = 'default'
 const LINKS_TABLE = 'any_links'
@@ -281,34 +282,6 @@ export const RestApiAnyapiKnexPlugin = {
       }
 
       return descriptors
-    }
-
-    const buildQueryString = (queryParams = {}) => {
-      const buildParts = (prefix, value) => {
-        const parts = []
-        if (Array.isArray(value)) {
-          if (value.length === 0) return parts
-          parts.push(`${prefix}=${value.map((item) => encodeURIComponent(item)).join(',')}`)
-          return parts
-        }
-        if (value && typeof value === 'object') {
-          for (const [key, subValue] of Object.entries(value)) {
-            if (subValue === undefined || subValue === null) continue
-            const newPrefix = `${prefix}[${key}]`
-            parts.push(...buildParts(newPrefix, subValue))
-          }
-          return parts
-        }
-        if (value === undefined || value === null) return parts
-        parts.push(`${prefix}=${encodeURIComponent(value)}`)
-        return parts
-      }
-
-      const parts = []
-      for (const [key, value] of Object.entries(queryParams)) {
-        parts.push(...buildParts(key, value))
-      }
-      return parts.length > 0 ? `?${parts.join('&')}` : ''
     }
 
     const applyPaginationToQuery = ({
@@ -2205,7 +2178,8 @@ export const RestApiAnyapiKnexPlugin = {
       }
 
       context.returnMeta = context.returnMeta || {}
-      context.returnMeta.queryString = buildQueryString(queryParams)
+      const queryString = serializeJsonApiQuery(queryParams)
+      context.returnMeta.queryString = queryString ? `?${queryString}` : ''
       delete context.returnMeta.paginationMeta
       delete context.returnMeta.paginationLinks
 

--- a/plugins/core/rest-api-knex-plugin.js
+++ b/plugins/core/rest-api-knex-plugin.js
@@ -38,6 +38,7 @@ import {
   parseSortEntry
 } from './lib/querying/query-field-sort-helpers.js'
 import { unwrapQueryBuilderState } from './lib/querying/query-builder-utils.js'
+import { serializeJsonApiQuery } from './lib/querying-writing/connectors-query-parser.js'
 
 export const RestApiKnexPlugin = {
   name: 'rest-api-knex',
@@ -767,38 +768,10 @@ export const RestApiKnexPlugin = {
       // Execute query
       const records = await query
 
-      // Store query string for response building
-      const queryParts = []
-      Object.entries(queryParams).forEach(([key, value]) => {
-        if (Array.isArray(value)) {
-          // Handle arrays (like sort, include)
-          if (value.length > 0) {
-            queryParts.push(`${key}=${value.map(v => encodeURIComponent(v)).join(',')}`)
-          }
-        } else if (typeof value === 'object' && value !== null) {
-          // Handle nested objects (like filters, fields, page)
-          Object.entries(value).forEach(([subKey, subValue]) => {
-            if (subValue !== undefined && subValue !== null) {
-              if (typeof subValue === 'object' && !Array.isArray(subValue)) {
-                // Handle deeply nested objects (like filters[country][code])
-                Object.entries(subValue).forEach(([subSubKey, subSubValue]) => {
-                  if (subSubValue !== undefined && subSubValue !== null) {
-                    queryParts.push(`${key}[${subKey}][${subSubKey}]=${encodeURIComponent(subSubValue)}`)
-                  }
-                })
-              } else {
-                queryParts.push(`${key}[${subKey}]=${encodeURIComponent(subValue)}`)
-              }
-            }
-          })
-        } else if (value !== undefined && value !== null) {
-          queryParts.push(`${key}=${encodeURIComponent(value)}`)
-        }
-      })
-
       // Initialize returnMeta namespace for thread-safe metadata
       context.returnMeta = context.returnMeta || {}
-      context.returnMeta.queryString = queryParts.length > 0 ? `?${queryParts.join('&')}` : ''
+      const queryString = serializeJsonApiQuery(queryParams)
+      context.returnMeta.queryString = queryString ? `?${queryString}` : ''
 
       // Execute count query for pagination if offset-based pagination is used
       if (queryParams.page?.number !== undefined || (queryParams.page?.size !== undefined && !queryParams.page?.after && !queryParams.page?.before)) {

--- a/plugins/core/rest-api-plugin-methods/common.js
+++ b/plugins/core/rest-api-plugin-methods/common.js
@@ -10,6 +10,10 @@ import {
   normalizeReturnRecordMode,
   normalizeReturnRecordSetting
 } from '../lib/querying-writing/return-record-settings.js'
+import {
+  getRequestContracts,
+  validateRequestContractOrThrow
+} from '../lib/querying-writing/request-contracts.js'
 
 export { normalizeReturnRecordMode as normalizeReturnValue }
 
@@ -160,6 +164,29 @@ export const commitOwnedTransaction = async (context, runHooks) => {
   await context.transaction.commit()
   context.transactionCommitted = true
   await runHooks('afterCommit')
+}
+
+export const validateRelationshipRoutePayload = ({
+  context,
+  vars,
+  scopeName,
+  operation,
+  relationshipData
+}) => {
+  const contracts = getRequestContracts({
+    scopeName,
+    schemaInfo: context.schemaInfo,
+    includeDepthLimit: vars.includeDepthLimit,
+    sortableFields: vars.sortableFields
+  })
+
+  const validated = validateRequestContractOrThrow(
+    contracts[operation],
+    { data: relationshipData },
+    `${operation} relationship request body is invalid`
+  )
+
+  return validated.data
 }
 
 /**

--- a/plugins/core/rest-api-plugin-methods/delete-relationship.js
+++ b/plugins/core/rest-api-plugin-methods/delete-relationship.js
@@ -1,5 +1,10 @@
-import { RestApiResourceError, RestApiValidationError, RestApiPayloadError } from '../../../lib/rest-api-errors.js'
-import { commitOwnedTransaction, findRelationshipDefinition, handleWriteMethodError } from './common.js'
+import { RestApiResourceError, RestApiValidationError } from '../../../lib/rest-api-errors.js'
+import {
+  commitOwnedTransaction,
+  findRelationshipDefinition,
+  handleWriteMethodError,
+  validateRelationshipRoutePayload
+} from './common.js'
 import {
   normalizeRelationshipIdentifiers,
   requireExistingResourceId
@@ -48,9 +53,13 @@ export default async function deleteRelationshipMethod ({ params, context, vars,
       )
     }
 
-    if (!Array.isArray(params.relationshipData)) {
-      throw new RestApiPayloadError('DELETE from relationship requires array of resource identifiers')
-    }
+    params.relationshipData = validateRelationshipRoutePayload({
+      context,
+      vars,
+      scopeName,
+      operation: 'deleteRelationship',
+      relationshipData: params.relationshipData
+    })
     params.relationshipData = normalizeRelationshipIdentifiers(params.relationshipData, { api })
 
     // Check permissions

--- a/plugins/core/rest-api-plugin-methods/patch-relationship.js
+++ b/plugins/core/rest-api-plugin-methods/patch-relationship.js
@@ -1,4 +1,8 @@
-import { commitOwnedTransaction, handleWriteMethodError } from './common.js'
+import {
+  commitOwnedTransaction,
+  handleWriteMethodError,
+  validateRelationshipRoutePayload
+} from './common.js'
 import { requireExistingResourceId } from '../lib/querying-writing/resource-id-normalization.js'
 
 /**
@@ -19,6 +23,7 @@ export default async function patchRelationshipMethod ({ params, context, vars, 
     scopeName
   })
   context.relationshipName = params.relationshipName
+  context.schemaInfo = scopes[scopeName].vars.schemaInfo
 
   // Transaction handling
   context.transaction = params.transaction ||
@@ -31,6 +36,14 @@ export default async function patchRelationshipMethod ({ params, context, vars, 
     await runHooks('checkPermissions')
     await runHooks('checkPermissionsPatchRelationship')
 
+    const relationshipData = validateRelationshipRoutePayload({
+      context,
+      vars,
+      scopeName,
+      operation: 'patchRelationship',
+      relationshipData: params.relationshipData
+    })
+
     // Reuse existing patch with relationship data
     await scope.patch({
       id: context.id,
@@ -39,7 +52,7 @@ export default async function patchRelationshipMethod ({ params, context, vars, 
           type: scopeName,
           id: context.id,
           relationships: {
-            [params.relationshipName]: { data: params.relationshipData }
+            [params.relationshipName]: { data: relationshipData }
           }
         }
       },

--- a/plugins/core/rest-api-plugin-methods/post-relationship.js
+++ b/plugins/core/rest-api-plugin-methods/post-relationship.js
@@ -1,5 +1,10 @@
-import { RestApiResourceError, RestApiValidationError, RestApiPayloadError } from '../../../lib/rest-api-errors.js'
-import { commitOwnedTransaction, findRelationshipDefinition, handleWriteMethodError } from './common.js'
+import { RestApiResourceError, RestApiValidationError } from '../../../lib/rest-api-errors.js'
+import {
+  commitOwnedTransaction,
+  findRelationshipDefinition,
+  handleWriteMethodError,
+  validateRelationshipRoutePayload
+} from './common.js'
 import { createPivotRecords } from '../lib/writing/many-to-many-manipulations.js'
 import {
   normalizeRelationshipIdentifiers,
@@ -50,9 +55,13 @@ export default async function postRelationshipMethod ({ params, context, vars, h
       )
     }
 
-    if (!Array.isArray(params.relationshipData)) {
-      throw new RestApiPayloadError('POST to relationship requires array of resource identifiers')
-    }
+    params.relationshipData = validateRelationshipRoutePayload({
+      context,
+      vars,
+      scopeName,
+      operation: 'postRelationship',
+      relationshipData: params.relationshipData
+    })
     params.relationshipData = normalizeRelationshipIdentifiers(params.relationshipData, { api })
 
     // Check permissions

--- a/tests/pagination-enhanced.test.js
+++ b/tests/pagination-enhanced.test.js
@@ -40,6 +40,8 @@ describe('Enhanced Pagination Features', () => {
   })
 
   describe('Self Links', () => {
+    let countryId
+
     beforeEach(async () => {
       await cleanTables(knex, [
         'pagination_countries', 'pagination_publishers', 'pagination_books'
@@ -51,6 +53,7 @@ describe('Enhanced Pagination Features', () => {
         inputRecord: countryDoc,
         simplified: false
       })
+      countryId = countryResult.data.id
 
       // Create some books
       for (let i = 1; i <= 3; i++) {
@@ -136,6 +139,38 @@ describe('Enhanced Pagination Features', () => {
       })
       assert(result.links, 'Response should have top-level links')
       assert(result.links.self.startsWith('/books'), 'Top-level self link should be relative')
+    })
+
+    it('should serialize collection self-link query parameters in JSON:API form', async () => {
+      const result = await api.resources.books.query({
+        queryParams: {
+          filters: {
+            country: countryId
+          },
+          fields: {
+            books: 'title,country_id',
+            countries: 'name,code'
+          },
+          include: ['country'],
+          sort: ['title']
+        },
+        simplified: false
+      })
+
+      validateJsonApiStructure(result, true)
+
+      const selfUrl = new URL(result.links.self, 'https://example.test')
+      const selfQuery = parseLinkQuery(result.links.self)
+
+      assert.equal(selfUrl.searchParams.get('filter[country]'), countryId)
+      assert.equal(selfUrl.searchParams.has('filters[country]'), false)
+      assert.deepEqual(selfQuery.filters, { country: countryId })
+      assert.deepEqual(selfQuery.include, ['country'])
+      assert.deepEqual(selfQuery.sort, ['title'])
+      assert.deepEqual(selfQuery.fields, {
+        books: 'title,country_id',
+        countries: 'name,code'
+      })
     })
   })
 

--- a/tests/relationship-endpoints.test.js
+++ b/tests/relationship-endpoints.test.js
@@ -400,6 +400,12 @@ describe('Relationship Endpoints Plugin', () => {
     let bookId
     let authorId
 
+    const assertRelationshipIdValidationError = (error) => {
+      assert.equal(error.code, 'REST_API_VALIDATION')
+      assert.match(error.message, /id/i)
+      return true
+    }
+
     beforeEach(async () => {
       await cleanTables(knex, [
         'basic_countries', 'basic_publishers', 'basic_authors', 'basic_books', 'basic_book_authors'
@@ -482,6 +488,39 @@ describe('Relationship Endpoints Plugin', () => {
 
       assert.equal(toManyResponse.status, 422)
       assert.match(toManyResponse.body.errors?.[0]?.detail || '', /array of resource identifiers/)
+    })
+
+    it('rejects malformed relationship identifiers through direct relationship methods', async () => {
+      await assert.rejects(
+        api.resources.books.postRelationship({
+          id: bookId,
+          relationshipName: 'authors',
+          relationshipData: [{ type: 'authors' }]
+        }),
+        assertRelationshipIdValidationError
+      )
+
+      await assert.rejects(
+        api.resources.books.patchRelationship({
+          id: bookId,
+          relationshipName: 'country',
+          relationshipData: { type: 'countries' }
+        }),
+        assertRelationshipIdValidationError
+      )
+    })
+
+    it('rejects malformed relationship identifiers through Express transport', async () => {
+      const response = await request(app)
+        .delete(`/books/${bookId}/relationships/authors`)
+        .set('Content-Type', 'application/vnd.api+json')
+        .set('Accept', 'application/vnd.api+json')
+        .send({
+          data: [{ type: 'authors' }]
+        })
+
+      assert.equal(response.status, 422)
+      assert.match(response.body.errors?.[0]?.detail || '', /id/i)
     })
   })
 


### PR DESCRIPTION
## Summary
- Use the shared JSON:API query serializer for legacy and AnyAPI fallback collection self links.
- Validate relationship route bodies through the shared request-contract schema before POST/PATCH/DELETE relationship writes.
- Add regression coverage for fallback self-link query keys and malformed relationship identifiers through direct and Express paths.

## Verification
- npm run lint
- npm test
- npm run test:anyapi
- npm run verify